### PR TITLE
Make pip install work with new version of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [project]
 name = "LiquidsReflectometer"
 description = "Reduction scripts for the Liquids Reflectometer. This includes both automated reduction scripts and useful scripts to reprocess data."
-dynamic = ["version"]
+dynamic = ["version", "readme", "license", "dependencies"]
 requires-python = ">=3.8"
-dependencies = [
-    "mantidworkbench"
+classifiers = [
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3"
 ]
 
 [tool.ruff]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,6 @@ author_email = m2d@ornl.gov
 url = https://github.com/neutrons/LiquidsReflectometer
 long_description = file: README.md
 license = BSD 3-Clause License
-classifiers =
-  Operating System :: OS Independent
-  Programming Language :: Python :: 3
 
 [options]
 include_package_data = False
@@ -22,6 +19,7 @@ install_requires =
     lmfit
     numpy
     matplotlib
+    mantidworkbench
 
 tests_require =
     mock


### PR DESCRIPTION
Installing using `pip install` is failing with error messages like:

`_MissingDynamic: license defined outside of pyproject.toml is ignored.`

This seems related to a new release of `setuptools`: https://stackoverflow.com/a/77527178

This PR changes `pyproject.toml` to follow current standards to be able to do `pip install`.

To test, make sure that pip install works and that the package metadata is shown as expected, especially the dynamic metadata that is pulled from `setup.cfg`.

```
$ pip install -e .
...
$ pip show --verbose LiquidsReflectometer
Name: LiquidsReflectometer
Version: 2.0.13
Summary: Reduction scripts for the Liquids Reflectometer. This includes both automated reduction scripts and useful scripts to reprocess data.
Home-page: https://github.com/neutrons/LiquidsReflectometer
Author: Mat
Author-email: m2d@ornl.gov
License: BSD 3-Clause License
Location: /home/u5z/mambaforge/envs/liqref/lib/python3.8/site-packages
Editable project location: /home/u5z/projects/LiquidsReflectometer
Requires: lmfit, mantidworkbench, matplotlib, numpy
Required-by: 
Metadata-Version: 2.1
Installer: pip
Classifiers:
  Operating System :: OS Independent
  Programming Language :: Python :: 3
Entry-points:
Project-URLs:
```

