### PR TITLE
Document creating releases but differentiate between major/minor/patch releases

### DIFF
--- a/docs/source/developer/developer.rst
+++ b/docs/source/developer/developer.rst
@@ -104,5 +104,38 @@ After this, point your browser to
 
 Creating a stable release
 -------------------------
-- Follow the `Software Maturity Model <https://ornl-neutrons.atlassian.net/wiki/spaces/NDPD/pages/23363585/Software+Maturity+Model>`_ for continous versioning as well as creating release candidates and stable releases.
-- Update the :ref:`Release Notes <release_notes>` with major fixes, updates and additions since last stable release.
+
+- *patch* release, it may be allowed to bypass the creation of a candidate release.
+  Still, we must update branch `qa` first, then create the release tag in branch `main`.
+  For instance, to create patch version "v2.1.1":
+
+.. code-block:: bash
+
+   VERSION="v2.1.2"
+   # update the local repository
+   git fetch --all --prune
+   git fetch --prune --prune-tags origin
+   # update branch qa from next, possibly bringing work done in qa missing in next
+   git switch next
+   git rebase -v origin/next
+   git merge --no-edit origin/qa  # commit message is automatically generated
+   git push origin next  # required to "link" qa to next, for future fast-forward
+   git switch qa
+   git rebase -v origin/qa
+   git merge --ff-only origin/next
+   # update branch main from qa
+   git merge --no-edit origin/main  # commit message is automatically generated
+   git push origin qa  # required to "link" main to qa, for future fast-forward
+   git switch main
+   git rebase -v origin/main
+   git merge --ff-only origin/qa
+   git tag $VERSIONv2.1.1
+   git push origin --tags main
+
+- *minor* or *major* release, we create a stable release *after* we have created a Candidate release.
+  For this customary procedure, follow:
+
+  + the `Software Maturity Model <https://ornl-neutrons.atlassian.net/wiki/spaces/NDPD/pages/23363585/Software+Maturity+Model>`_ for continous versioning as well as creating release candidates and stable releases.
+  + Update the :ref:`Release Notes <release_notes>` with major fixes, updates and additions since last stable release.
+
+

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -14,7 +14,7 @@ Notes for major or minor releases. Notes for patch releases are deferred
 
 **Of interest to the Developer:**
 
-- PR #XYZ one-liner description
+- PR #40 documentation to create a patch release
 
 2.1.0
 -----


### PR DESCRIPTION
## Description of work:

Check all that apply:
- [x] added [release notes](https://github.com/neutrons/LiquidsReflectometer/blob/next/docs/source/releases.rst) (if not, provide an explanation in the work description)
- [x] updated documentation
- [ ] ~~Source added/refactored~~
- [ ] ~~Added unit tests~~
- [ ] ~~Added integration tests~~
- [ ] ~~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~~

**References:**
- Links to IBM EWM items: [6499](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6499), [6502](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6502)

## Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/LiquidsReflectometer/blob/next/docs/source/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

