### PR TITLE
use correct env

### DIFF
--- a/launcher/apps/dynamic_60Hz.py
+++ b/launcher/apps/dynamic_60Hz.py
@@ -161,12 +161,14 @@ class Dynamic60Hz(QWidget):
         print("Reduce!")
 
         reduction_script='scripts/time_resolved_reduction.py'
-        args = ['python3', reduction_script, 'template',
-                 self.data_run_number_ledit.text(),
-                 self.template_path.text(),
-                 self.time_slice_ledit.text(),
-                 self.output_dir_label.text(),
-                 '--scan_index', self.idx_ledit.text()
+        args = ['nsd-conda-wrap.sh', 'mantid',
+                '--classic',
+                reduction_script, 'template',
+                self.data_run_number_ledit.text(),
+                self.template_path.text(),
+                self.time_slice_ledit.text(),
+                self.output_dir_label.text(),
+                '--scan_index', self.idx_ledit.text()
                 ]
         offset = self.fix_offset_ledit.text()
         if self.fix_offset_check.isChecked():

--- a/launcher/scripts/time_resolved_reduction.py
+++ b/launcher/scripts/time_resolved_reduction.py
@@ -3,6 +3,7 @@ import argparse
 
 sys.path.append("/SNS/REF_L/shared/reduction")
 
+
 from lr_reduction import time_resolved
 
 

--- a/reduction/lr_reduction/time_resolved.py
+++ b/reduction/lr_reduction/time_resolved.py
@@ -286,7 +286,6 @@ def reduce_slices_ws(meas_ws, template_file,
             np.savetxt(os.path.join(output_dir, _filename), _reduced.T)
         except:
             print("reduce_slices_ws: %s" % sys.exc_info()[0])
-            raise
         total_time += time_interval
 
     if create_plot:

--- a/reduction/lr_reduction/time_resolved.py
+++ b/reduction/lr_reduction/time_resolved.py
@@ -15,7 +15,7 @@ from matplotlib import pyplot as plt
 mantid.kernel.config.setLogLevel(3)
 
 from . import template
-from .event_reduction import compute_resolution
+from .event_reduction import apply_dead_time_correction, compute_resolution
 
 
 def reduce_30Hz_from_ws(meas_ws_30Hz, ref_ws_30Hz, data_60Hz, template_data, scan_index=1, # noqa ARG001
@@ -223,6 +223,16 @@ def reduce_slices_ws(meas_ws, template_file,
         :param theta_value: force theta value
         :param theta_offset: add a theta offset, defaults to zero
     """
+    # Save options
+    options = dict(meas_run=meas_ws.getRun()['run_number'].value,
+                   template=template_file,
+                   time_interval=time_interval,
+                   output_dir=output_dir,
+                   scan_index=scan_index,
+                   theta_value=theta_value,
+                   theta_offset=theta_offset)
+    with open(os.path.join(output_dir, 'options.json'), 'w') as fp:
+        json.dump(options, fp)
 
     # Load the template
     print("Reading template")
@@ -244,6 +254,11 @@ def reduce_slices_ws(meas_ws, template_file,
     except:
         meas_run = 0
 
+    # Apply dead time correction up front since we are using the error events but
+    # not filtering them.
+    if template_data.dead_time:
+        apply_dead_time_correction(meas_ws, template_data)
+
     # Time slices
     print("Slicing data")
     splitws, infows = api.GenerateEventsFilter(InputWorkspace=meas_ws, TimeInterval=time_interval)
@@ -264,6 +279,13 @@ def reduce_slices_ws(meas_ws, template_file,
 
     # Load DB so we do it only once
     ws_db = api.LoadEventNexus("REF_L_%s" % template_data.norm_file)
+
+    # Apply dead time correction up-front
+    if template_data.dead_time:
+        apply_dead_time_correction(ws_db, template_data)
+
+    # Turn off dead time since we already did it
+    template_data.dead_time = False
 
     reduced = []
     total_time = 0

--- a/scripts/shared/batch_reduce.py
+++ b/scripts/shared/batch_reduce.py
@@ -5,7 +5,7 @@ import time
 import subprocess
 
 
-PYTHON_CMD = 'nsd-conda-wrap.sh mantid-dev'
+PYTHON_CMD = 'nsd-conda-wrap.sh mantid'
 
 if len(sys.argv) < 4:
     print("\nUsage: python3 batch_reduce.py <IPTS> <first run> <last run>")


### PR DESCRIPTION
Make sure the correct env is used for batch reduction (`mantid`, not `mantid-dev`).
Make sure the correct env is used for the time-resolved reduction.
