### PR TITLE
Fix q-summing for up/down reflection

### DIFF
--- a/reduction/lr_reduction/event_reduction.py
+++ b/reduction/lr_reduction/event_reduction.py
@@ -623,12 +623,7 @@ class EventReflectivity(object):
                     wl_weights = 1.0/np.interp(wl_list, wl_bins, wl_dist, np.inf, np.inf)
                     hist_weights = wl_weights * qz / wl_list
                     hist_weights *= event_weights
-                    #_wl_q_bins = 4.0 * np.pi / _q_bins * np.sin(theta + delta_theta_f)
-                    #_wl_width = np.fabs(_wl_q_bins[1:] - _wl_q_bins[:-1])
                     _counts, _ = np.histogram(qz, bins=_q_bins, weights=hist_weights)
-                    _width = np.fabs(_q_bins[1:] - _q_bins[:-1])
-
-                    _counts /= _width
                     _norm, _ = np.histogram(qz, bins=_q_bins)
                     if sum_pixels:
                         refl += _counts
@@ -663,8 +658,8 @@ class EventReflectivity(object):
             if not sum_pixels:
                 bin_size = np.tile(bin_size, [counts.shape[0], 1])
 
-            d_refl_sq[non_zero] =  refl[non_zero] / np.sqrt(counts[non_zero]) / charge #/ bin_size[non_zero]
-            refl[non_zero] = refl[non_zero] / charge #/ bin_size[non_zero]
+            d_refl_sq[non_zero] =  refl[non_zero] / np.sqrt(counts[non_zero]) / charge / bin_size[non_zero]
+            refl[non_zero] = refl[non_zero] / charge / bin_size[non_zero]
         else:
             d_refl_sq = np.sqrt(np.fabs(refl)) / charge
             refl /= charge

--- a/reduction/lr_reduction/event_reduction.py
+++ b/reduction/lr_reduction/event_reduction.py
@@ -761,9 +761,11 @@ class EventReflectivity(object):
             k = 2.0 * np.pi / wl_list
             wl_weights = 1.0/np.interp(wl_list, wl_bins, wl_dist, np.inf, np.inf)
 
-            #TODO: Sign with depend on reflect up or down
             x_distance = float(j-peak_position) * self.pixel_width
             delta_theta_f = np.arctan(x_distance / self.det_distance)
+            # Sign will depend on reflect up or down
+            ths_value = ws.getRun()['ths'].value[-1]
+            delta_theta_f *= ths_value / np.fabs(ths_value)
             theta_f = theta + delta_theta_f
 
             qz = k * (np.sin(theta_f) + np.sin(theta))

--- a/reduction/lr_reduction/event_reduction.py
+++ b/reduction/lr_reduction/event_reduction.py
@@ -614,7 +614,7 @@ class EventReflectivity(object):
 
                 # Sign will depend on reflect up or down
                 ths_value = ws.getRun()['ths'].value[-1]
-                delta_theta_f *= ths_value / np.fabs(ths_value)
+                delta_theta_f *= np.sign(ths_value)
 
                 qz=4.0*np.pi/wl_list * np.sin(theta + delta_theta_f - d_theta)
                 qz = np.fabs(qz)
@@ -766,7 +766,7 @@ class EventReflectivity(object):
             delta_theta_f = np.arctan(x_distance / self.det_distance)
             # Sign will depend on reflect up or down
             ths_value = ws.getRun()['ths'].value[-1]
-            delta_theta_f *= ths_value / np.fabs(ths_value)
+            delta_theta_f *= np.sign(ths_value)
             theta_f = theta + delta_theta_f
 
             qz = k * (np.sin(theta_f) + np.sin(theta))

--- a/reduction/lr_reduction/template.py
+++ b/reduction/lr_reduction/template.py
@@ -9,7 +9,7 @@ import numpy as np
 from mantid.api import *
 from mantid.kernel import *
 
-from . import event_reduction, reduction_template_reader
+from . import event_reduction, peak_finding, reduction_template_reader
 
 TOLERANCE = 0.07
 OUTPUT_NORM_DATA = False
@@ -207,8 +207,17 @@ def process_from_template_ws(ws_sc, template_data, q_summing=False,
     else:
         peak_bck = None
 
-    #TODO: Fit this peak
     peak_center = (peak[0]+peak[1])/2.0
+
+    # Fit the reflected beam position, which may not be in the middle and is
+    # used in the q-summing calculation
+    if q_summing:
+        x_min=template_data.data_peak_range[0]
+        x_max=template_data.data_peak_range[1]
+        _, _x, _y = peak_finding.process_data(ws_sc, summed=True, tof_step=200)
+        peak_center = np.argmax(_y[x_min:x_max]) + x_min
+        peak_center, sc_width, _ = peak_finding.fit_signal_flat_bck(_x, _y, x_min=x_min, x_max=x_max, center=peak_center, sigma=3.)
+        print("Peak center: %g" % peak_center)
 
     if template_data.data_x_range_flag:
         low_res = template_data.data_x_range

--- a/reduction/lr_reduction/template.py
+++ b/reduction/lr_reduction/template.py
@@ -167,7 +167,7 @@ def process_from_template_ws(ws_sc, template_data, q_summing=False,
             ws_db = event_reduction.process_attenuation(ws_db, thickness=attenuator_thickness)
 
     # Apply dead time correction
-    if template_data.dead_time:
+    if normalize and template_data.dead_time:
         ws_db = event_reduction.apply_dead_time_correction(ws_db, template_data)
 
     # If we run in theta-theta geometry, we'll need thi

--- a/reduction/lr_reduction/workflow.py
+++ b/reduction/lr_reduction/workflow.py
@@ -44,7 +44,7 @@ def reduce(ws, template_file, output_dir, average_overlap=False,
     # Call the reduction using the template
     qz_mid, refl, d_refl, meta_data = template.process_from_template_ws(ws, template_data,
                                                                         q_summing=q_summing,
-                                                                        tof_weighted=q_summing,
+                                                                        tof_weighted=False,
                                                                         clean=q_summing,
                                                                         bck_in_q=bck_in_q,
                                                                         info=True)


### PR DESCRIPTION
The way we compute the q offset according to counts in pixels in y needs to account for whether we reflect up or down. This PR fixes that.

For a correct calculation, we also need the reflected peak's true center, not just the center of the range.