### PR TITLE
Fix event weights in weighted reflectivity calculation

### DIFF
--- a/reduction/lr_reduction/workflow.py
+++ b/reduction/lr_reduction/workflow.py
@@ -44,7 +44,7 @@ def reduce(ws, template_file, output_dir, average_overlap=False,
     # Call the reduction using the template
     qz_mid, refl, d_refl, meta_data = template.process_from_template_ws(ws, template_data,
                                                                         q_summing=q_summing,
-                                                                        tof_weighted=False,
+                                                                        tof_weighted=bck_in_q,
                                                                         clean=q_summing,
                                                                         bck_in_q=bck_in_q,
                                                                         info=True)


### PR DESCRIPTION
One option for normalization when computing R is to assign a weight to each event according to the flux spectrum. This allows to bin easily in Q, Qx-Qz, etc.. The implementation didn't account for the recent addition of the dead time correction.
This PR fixes that.