### PR TITLE
Update dq for q summing

### DIFF
--- a/reduction/lr_reduction/output.py
+++ b/reduction/lr_reduction/output.py
@@ -137,8 +137,6 @@ class RunCollection():
                 initial_entry_written = True
 
             # Write R(q)
-            fd.write('# dQ0[1/Angstrom] = %g\n' % _meta['dq0'])
-            fd.write('# dQ/Q = %g\n' % _meta['dq_over_q'])
             fd.write('# %-21s %-21s %-21s %-21s\n' % ('Q [1/Angstrom]', 'R', 'dR', 'dQ [FWHM]'))
             for i in range(len(self.qz_all)):
                 fd.write('%20.16f  %20.16f  %20.16f  %20.16f\n' % (self.qz_all[i], self.refl_all[i], self.d_refl_all[i], self.d_qz_all[i]))

--- a/reduction/test/test_reduction.py
+++ b/reduction/test/test_reduction.py
@@ -1,6 +1,6 @@
 # standard imports
-from pathlib import Path
 import os
+from pathlib import Path
 
 # third-party imports
 import mantid
@@ -10,7 +10,6 @@ import numpy as np
 # lr_reduction imports
 from lr_reduction import event_reduction, template, workflow
 from lr_reduction.utils import amend_config
-
 
 mtd_api.config["default.facility"] = "SNS"
 mtd_api.config["default.instrument"] = "REF_L"
@@ -45,6 +44,33 @@ def test_attenuation(nexus_dir):
     with amend_config(data_dir=nexus_dir):
         ws_sc = mtd_api.Load("REF_L_198409")
     event_reduction.process_attenuation(ws_sc, 0.005)
+
+
+def test_q_summing(nexus_dir):
+    """
+        Test Q summing process
+    """
+    template_path = 'data/template.xml'
+    template.read_template(template_path, 7)
+    with amend_config(data_dir=nexus_dir):
+            ws_sc = mtd_api.Load("REF_L_%s" % 198415)
+    qz_mid0, refl0, d_refl0, meta_data = template.process_from_template_ws(ws_sc, template_path, info=True)
+
+    assert(np.fabs(meta_data['dq_over_q'] - 0.02759) < 1e-3)
+
+    # Now try with Q summing, which should have similar results
+    qz_mid, refl, d_refl, meta_data = template.process_from_template_ws(ws_sc, template_path,
+                                                                        info=True, q_summing=True)
+
+    assert(np.fabs(meta_data['dq_over_q'] - 0.009354) < 1e-5)
+
+    np.loadtxt('data/reference_rq.txt').T
+    assert(len(qz_mid0) == len(qz_mid))
+    assert(np.fabs(np.mean(refl-refl0)) < 1e-6)
+
+    # Cleanup
+    output_dir = 'data/'
+    cleanup_partial_files(output_dir, range(198409, 198417))
 
 
 def test_full_reduction(nexus_dir):

--- a/reduction/test/test_reduction.py
+++ b/reduction/test/test_reduction.py
@@ -54,19 +54,21 @@ def test_q_summing(nexus_dir):
     template.read_template(template_path, 7)
     with amend_config(data_dir=nexus_dir):
             ws_sc = mtd_api.Load("REF_L_%s" % 198415)
-    qz_mid0, refl0, d_refl0, meta_data = template.process_from_template_ws(ws_sc, template_path, info=True)
+    qz_mid0, refl0, _, meta_data = template.process_from_template_ws(ws_sc, template_path, info=True)
 
     assert(np.fabs(meta_data['dq_over_q'] - 0.02759) < 1e-3)
 
     # Now try with Q summing, which should have similar results
-    qz_mid, refl, d_refl, meta_data = template.process_from_template_ws(ws_sc, template_path,
+    qz_mid, refl, _, meta_data = template.process_from_template_ws(ws_sc, template_path,
+                                                                        tof_weighted=True,
                                                                         info=True, q_summing=True)
 
     assert(np.fabs(meta_data['dq_over_q'] - 0.009354) < 1e-5)
 
-    np.loadtxt('data/reference_rq.txt').T
-    assert(len(qz_mid0) == len(qz_mid))
-    assert(np.fabs(np.mean(refl-refl0)) < 1e-6)
+    # Note that TOF weighted may have a slightly different range, so here we skip
+    # the extra point.
+    assert(len(qz_mid0) == len(qz_mid[1:]))
+    assert(np.fabs(np.mean(refl[1:]-refl0)) < 1e-6)
 
     # Cleanup
     output_dir = 'data/'


### PR DESCRIPTION
When summing in Q, the resolution should be computed differently. The geometric part is only related to pixel size.
This PR add this to the Q-summing option. It also cleans up the output files.