### PR TITLE
Update event_reduction.py

### DIFF
--- a/reduction/lr_reduction/event_reduction.py
+++ b/reduction/lr_reduction/event_reduction.py
@@ -891,8 +891,8 @@ class EventReflectivity:
                 delta_theta_f = np.arctan(x_distance / self.sample_detector_distance) / 2.0
 
                 # Sign will depend on reflect up or down
-                ths_value = ws.getRun()["ths"].value[-1]
-                delta_theta_f *= np.sign(ths_value)
+                tthd_value = ws.getRun()["tthd"].value[-1]
+                delta_theta_f *= np.sign(tthd_value)
 
                 qz = 4.0 * np.pi / wl_list * np.sin(theta + delta_theta_f - d_theta)
                 qz = np.fabs(qz)
@@ -1054,8 +1054,8 @@ class EventReflectivity:
             x_distance = float(j - peak_position) * self.pixel_width
             delta_theta_f = np.arctan(x_distance / self.sample_detector_distance)
             # Sign will depend on reflect up or down
-            ths_value = ws.getRun()["ths"].value[-1]
-            delta_theta_f *= np.sign(ths_value)
+            tthd_value = ws.getRun()["tthd"].value[-1]
+            delta_theta_f *= np.sign(tthd_value)
             theta_f = theta + delta_theta_f
 
             qz = k * (np.sin(theta_f) + np.sin(theta))


### PR DESCRIPTION
Constant-Q binning depends on knowing whether we are reflecting up or down. This was done using the `ths` value, but that won't work for free liquids. Changing to `tthd`.