### PR TITLE
Fix off-spec sign determination

### DIFF
--- a/reduction/lr_reduction/event_reduction.py
+++ b/reduction/lr_reduction/event_reduction.py
@@ -884,8 +884,8 @@ class EventReflectivity:
                 delta_theta_f = np.arctan(x_distance / self.sample_detector_distance) / 2.0
 
                 # Sign will depend on reflect up or down
-                tthd_value = ws.getRun()["tthd"].value[-1]
-                delta_theta_f *= np.sign(tthd_value)
+                ths_value = ws.getRun()["ths"].value[-1]
+                delta_theta_f *= np.sign(ths_value)
 
                 qz = 4.0 * np.pi / wl_list * np.sin(theta + delta_theta_f - d_theta)
                 qz = np.fabs(qz)
@@ -1047,8 +1047,10 @@ class EventReflectivity:
             x_distance = float(j - peak_position) * self.pixel_width
             delta_theta_f = np.arctan(x_distance / self.sample_detector_distance)
             # Sign will depend on reflect up or down
-            tthd_value = ws.getRun()["tthd"].value[-1]
-            delta_theta_f *= np.sign(tthd_value)
+            ths_value = ws.getRun()["ths"].value[-1]
+            delta_theta_f *= np.sign(ths_value)
+
+            
             theta_f = theta + delta_theta_f
 
             qz = k * (np.sin(theta_f) + np.sin(theta))


### PR DESCRIPTION
When computing Q for off-specular scattering (or for constant Q binning), we need know whether we were reflecting up or down in order to know the sign of the angle offset.

In the present code, this was done by looking at the sign of `tthd`. That works, except for last cycle when the detector arm was parked. A better solution would be to use `ths` (the sample stage), which should always be correct.

Note: this was found while helping the 4B SA with off-specular data. I would suggest passing this be the rest of the 4B team/CIS.
