### PR TITLE
More restrictive mantid

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 ## Description of work:
 
 Check all that apply:
-- [ ] added [release notes](https://github.com/neutrons/LiquidsReflectometer/blob/next/docs/source/releases.rst) (if not, provide an explanation in the work description)
 - [ ] updated documentation
 - [ ] Source added/refactored
 - [ ] Added unit tests
@@ -12,11 +11,10 @@ Check all that apply:
 - Links to IBM EWM items:
 - Links to related issues or pull requests:
 
-## Manual test for the reviewer
+## :warning: Manual test for the reviewer
 (Instructions for testing here)
 
 ## Check list for the reviewer
-- [ ] [release notes](https://github.com/neutrons/LiquidsReflectometer/blob/next/docs/source/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
 - [ ] best software practices
     + [ ] clearly named variables (better to be verbose in variable names)
     + [ ] code comments explaining the intent of code blocks

--- a/pixi.lock
+++ b/pixi.lock
@@ -3445,8 +3445,8 @@ packages:
   timestamp: 1741832212476
 - pypi: ./
   name: lr-reduction
-  version: 2.3.0.dev5
-  sha256: 3de200fee6845601b3af5ea3fc8bf5b1d36d87b68e90c25396ad7fe2119aba50
+  version: 2.3.0.dev6
+  sha256: fded96670a8cc06ad23850f4513a30f990abe874f82eee130ab72b5682f005a1
   requires_python: '>=3.10'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ hatchling = ">=1.27.0,<2"
 #   run-dependiencies replicated here
 python = ">=3.10"
 lmfit = "*"
-mantid = ">=6.12.0"
+mantid = "=6.12.0"
 matplotlib = "==3.9.4"
 pyqt = ">=5,<6"
 qtpy = ">=2.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ hatchling = ">=1.27.0,<2"
 #   run-dependiencies replicated here
 python = ">=3.10"
 lmfit = "*"
-mantid = "=6.12.0"
+mantid = ">=6.12.0,<6.13.0"
 matplotlib = "==3.9.4"
 pyqt = ">=5,<6"
 qtpy = ">=2.4.3"


### PR DESCRIPTION
## Description of work:
6.12.0 requires python 3.10 but 6.13.0 requires python 3.11. Turns out this is a big change that should be taken with care. For example, `refred-qa.yml` is requiring to explicitly set the mantid dependency to `6.12.0` when it should not be necessary. This package should define the mantid version.

Check all that apply:
- [ ] ~updated documentation~
- [x] Source added/refactored
- [ ] ~Added unit tests~
- [ ] ~Added integration tests~
- [ ] ~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~

**References:**
- ~Links to IBM EWM items:~

## Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] [release notes](https://github.com/neutrons/LiquidsReflectometer/blob/next/docs/source/releases.rst) updated, or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
