### PR TITLE
Fixing gravity correction sign handling

### DIFF
--- a/reduction/lr_reduction/event_reduction.py
+++ b/reduction/lr_reduction/event_reduction.py
@@ -359,6 +359,7 @@ class EventReflectivity:
         dead_time_threshold: Optional[float] = 1.5,
         instrument_settings: InstrumentSettings = None,
         use_emission_time=True,
+        grav_direction=None
     ):
         if instrument in [self.INSTRUMENT_4A, self.INSTRUMENT_4B]:
             self.instrument = instrument
@@ -389,6 +390,7 @@ class EventReflectivity:
         self.dead_time_threshold = dead_time_threshold
         self.instrument_settings = instrument_settings
         self.use_emission_time = use_emission_time
+        self.grav_direction = grav_direction
 
         # Turn on functional background estimation
         self.use_functional_bck = functional_background
@@ -888,7 +890,11 @@ class EventReflectivity:
                 wl_list = tofs / self.constant
 
                 # Gravity correction
-                d_theta = self.gravity_correction(ws, wl_list)
+                # check on value in template for gravity correction:
+                if self.grav_direction is not None:
+                    d_theta = self.gravity_correction(ws, wl_list, grav_dir=self.grav_direction)
+                else:
+                    d_theta = self.gravity_correction(ws, wl_list)
                 event_weights = evt_list.getWeights()
 
                 x_distance = _pixel_width * (j - peak_position)
@@ -898,7 +904,8 @@ class EventReflectivity:
                 ths_value = ws.getRun()["ths"].value[-1]
                 delta_theta_f *= np.sign(ths_value)
 
-                qz = 4.0 * np.pi / wl_list * np.sin(theta + delta_theta_f - d_theta)
+                # TODO: Check in code for any other calls of gravity_correction.
+                qz = 4.0 * np.pi / wl_list * np.sin(theta + delta_theta_f + d_theta)
                 qz = np.fabs(qz)
 
                 if wl_dist is not None and wl_bins is not None:
@@ -1121,7 +1128,7 @@ class EventReflectivity:
             tofs -= t_off + t_mult * tofs / self.constant
         return tofs
 
-    def gravity_correction(self, ws, wl_list):
+    def gravity_correction(self, ws, wl_list, thet_in=None, grav_dir=None):
         """
         Gravity correction for each event
 
@@ -1131,6 +1138,11 @@ class EventReflectivity:
             Mantid workspace to extract correction meta-data from.
         wl_list : numpy.ndarray
             Array of wavelengths for each event.
+        thet_in : float
+            Optional float to specify theta in, otherwise defaults to log values.
+        grav_dir : float
+            Optional float to specify gravity direction, otherwise defaults to ths sign.
+            (i.e. can change with +1, -1 or 0 to turn off)
 
         Returns
         -------
@@ -1155,8 +1167,23 @@ class EventReflectivity:
         sample_si_distance = xi_reference - xi
         slit_distance = s1_sample_distance - sample_si_distance
 
-        # Angle of the incident beam on a horizontal sample
-        theta_in = -4.0
+        if thet_in is not None:
+            theta_in = thet_in
+        else:
+            # Angle calculated from thi and a flag on earth-centered vs beam-centered
+            thi_val = ws.getRun().getProperty("BL4B:Mot:thi.RBV").value[0]
+
+            if ws.getInstrument().hasParameter("BL4B:Mot:EarthMode"): ##add real one!
+                if ws.getInstrument().hasParameter("BL4B:Mot:EarthMode").value[0] == "Earth":
+                    theta_in = thi_val
+                else:
+                    theta_in = thi_val - 4.0
+
+            elif ("BL4B:CS:ExpPl:OperatingMode" in ws.getRun()
+                and ws.getRun().getProperty("BL4B:CS:ExpPl:OperatingMode").value[0] == "Free Liquid"):
+                theta_in = thi_val
+            else:
+                theta_in = thi_val - 4.0 ##what to use as backup?
 
         # Calculation from the ILL paper. This works for inclined beams.
         # Calculated theta is the angle on the sample
@@ -1185,7 +1212,17 @@ class EventReflectivity:
         # Angle is arctan(dy/dx) at sample
         theta_sample = np.arctan(2 * k * (x0 - xs)) * 180 / np.pi
 
-        return (theta_sample - theta_in) * np.pi / 180.0
+        if grav_dir:
+            grav_direction = grav_dir
+        else:
+            # Determine sign of the correction term based on THS setup
+            ths_val = abs(ws.getRun().getProperty("BL4B:Mot:ths.RBV").value[0])
+            if ths_val < -0.001:
+                grav_direction= -1
+            else:
+                grav_direction = 1
+
+        return grav_direction*(theta_sample - theta_in) * np.pi / 180.0
 
 
 def compute_resolution(ws, default_dq=0.027, theta=None, q_summing=False):

--- a/reduction/lr_reduction/event_reduction.py
+++ b/reduction/lr_reduction/event_reduction.py
@@ -1182,7 +1182,7 @@ class EventReflectivity:
             thi_val = ws.getRun().getProperty("BL4B:Mot:thi.RBV").value[0]
 
             if ws.getInstrument().hasParameter("BL4B:CS:Mode:Coordinates"):
-                if ws.getInstrument().hasParameter("BL4B:CS:Mode:Coordinates").value[0] == "Earth-centered":
+                if ws.getRun().getProperty("BL4B:CS:Mode:Coordinates").value[0] == 0: # Earth-centered=0
                     theta_in = thi_val
                 else:
                     theta_in = thi_val - 4.0

--- a/reduction/lr_reduction/event_reduction.py
+++ b/reduction/lr_reduction/event_reduction.py
@@ -893,6 +893,14 @@ class EventReflectivity:
                 # check on value in template for gravity correction:
                 if self.grav_direction is not None:
                     d_theta = self.gravity_correction(ws, wl_list, grav_dir=self.grav_direction)
+                # Build in ability to use current unweighted workflow which needs to use the same grav corr
+                elif peak_position == 0:
+                    ths_val_RB = abs(self._ws_sc.getRun().getProperty("BL4B:Mot:ths.RBV").value[0])
+                    if ths_val_RB < -0.001:
+                        grav_direction= -1
+                    else:
+                        grav_direction = 1
+                    d_theta = self.gravity_correction(ws, wl_list, grav_dir=grav_direction)
                 else:
                     d_theta = self.gravity_correction(ws, wl_list)
                 event_weights = evt_list.getWeights()

--- a/reduction/lr_reduction/event_reduction.py
+++ b/reduction/lr_reduction/event_reduction.py
@@ -1181,8 +1181,8 @@ class EventReflectivity:
             # Angle calculated from thi and a flag on earth-centered vs beam-centered
             thi_val = ws.getRun().getProperty("BL4B:Mot:thi.RBV").value[0]
 
-            if ws.getInstrument().hasParameter("BL4B:Mot:EarthMode"): ##add real one!
-                if ws.getInstrument().hasParameter("BL4B:Mot:EarthMode").value[0] == "Earth":
+            if ws.getInstrument().hasParameter("BL4B:CS:Mode:Coordinates"):
+                if ws.getInstrument().hasParameter("BL4B:CS:Mode:Coordinates").value[0] == "Earth-centered":
                     theta_in = thi_val
                 else:
                     theta_in = thi_val - 4.0
@@ -1227,8 +1227,10 @@ class EventReflectivity:
             ths_val = abs(ws.getRun().getProperty("BL4B:Mot:ths.RBV").value[0])
             if ths_val < -0.001:
                 grav_direction= -1
+                print('Using gravity direction: negative')
             else:
                 grav_direction = 1
+                print('Using gravity direction: positive')
 
         return grav_direction*(theta_sample - theta_in) * np.pi / 180.0
 

--- a/reduction/lr_reduction/reduction_template_reader.py
+++ b/reduction/lr_reduction/reduction_template_reader.py
@@ -88,6 +88,8 @@ class ReductionParameters:
         # Calculate emission time delay instead of using an effective distance for all wavelengths
         self.use_emission_time: bool = True
 
+        self.gravity_direction = None
+
     def from_dict(self, data_dict, permissible=True):
         """
         Update object's attributes with a dictionary with entries of the type  attribute_name: attribute_value.
@@ -187,6 +189,8 @@ class ReductionParameters:
         _xml += "<pixel_width>%s</pixel_width>\n" % str(self.pixel_width)
         _xml += "<xi_reference>%s</xi_reference>\n" % str(self.xi_reference)
         _xml += "<s1_sample_distance>%s</s1_sample_distance>\n" % str(self.s1_sample_distance)
+
+        _xml += "<gravity_direction>%s</gravity_direction>\n" % str(self.gravity_direction)
 
         # Emission time correction
         _xml += "<use_emission_time>%s</use_emission_time>\n" % str(self.use_emission_time)
@@ -305,6 +309,8 @@ class ReductionParameters:
         self.pixel_width = getFloatElement(instrument_dom, "pixel_width", default=self.pixel_width)
         self.xi_reference = getFloatElement(instrument_dom, "xi_reference", default=self.xi_reference)
         self.s1_sample_distance = getFloatElement(instrument_dom, "s1_sample_distance", default=self.s1_sample_distance)
+
+        self.gravity_direction = getFloatElement(instrument_dom, "gravity_direction", default=self.gravity_direction)
 
         # Emission time
         # Defaults to True, but will be skipped if the necessary meta data is not found

--- a/reduction/lr_reduction/template.py
+++ b/reduction/lr_reduction/template.py
@@ -292,6 +292,7 @@ def process_from_template_ws(
         dead_time_threshold=template_data.dead_time_threshold,
         instrument_settings=instrument_settings,
         use_emission_time=template_data.use_emission_time,
+        gravity_direction=template_data.gravity_direction
     )
     print(f"{'*'*88}\nevent_refl:\n{event_refl}\n{'*'*88}")
 

--- a/reduction/lr_reduction/template.py
+++ b/reduction/lr_reduction/template.py
@@ -292,7 +292,7 @@ def process_from_template_ws(
         dead_time_threshold=template_data.dead_time_threshold,
         instrument_settings=instrument_settings,
         use_emission_time=template_data.use_emission_time,
-        gravity_direction=template_data.gravity_direction
+        grav_direction=template_data.gravity_direction
     )
     print(f"{'*'*88}\nevent_refl:\n{event_refl}\n{'*'*88}")
 


### PR DESCRIPTION
Gravity correction was always applied in the same direction irrespective of the reflection direction and had a fixed incident angle. This has been fixed.

The calculation algorithm takes into account the angle and direction from the log values of the workspace, with optional parameters to override and set these values for testing purposes.
A new PV has been added for determining the earth-centered vs beam-centered direction, with backwards compatibility using the "Free Liquid" flag.

Where the gravity_correction algorithm is called in the `event_reduction._reflectivity` function additional checks are added to:
(i) read from a new entry in the reduction template if it is present, which allows an experiment to be easily processed with different settings if needed.
(ii) apply the same gravity direction for the direct beam and run in the specular_unweighted workflow. Note we are aiming to move away from this workflow but it is the method currently used.

Points I need help checking:
- compatibility into RefRed. I don't think there should be an issue but haven't been able to test yet. May need to check that RefRed uses the same functions for writing out the template, but think the logic should all pull through the main lr_reduction workflow.
- check that nowhere else calls the `event_reduction.gravity_correction` algorithm in RefRed and lr_reduction. I couldn't find it but not sure the best way to search.