### PR TITLE
Fix q binning flag logic

### DIFF
--- a/reduction/data/template.xml
+++ b/reduction/data/template.xml
@@ -44,7 +44,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>15.0</norm_lambda_requested>
    <norm_dataset>198399</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -91,7 +90,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>12.386</norm_lambda_requested>
    <norm_dataset>198400</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -138,7 +136,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>9.74</norm_lambda_requested>
    <norm_dataset>198401</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -185,7 +182,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>7.043</norm_lambda_requested>
    <norm_dataset>198402</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -232,7 +228,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -279,7 +274,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -326,7 +320,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -373,7 +366,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>

--- a/reduction/data/template_201282.xml
+++ b/reduction/data/template_201282.xml
@@ -44,7 +44,6 @@
    <norm_to_back_pixels>148</norm_to_back_pixels>
    <norm_lambda_requested>15.0</norm_lambda_requested>
    <norm_dataset>201043</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <overlap_lowest_error>True</overlap_lowest_error>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
@@ -95,7 +94,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>12.386</norm_lambda_requested>
    <norm_dataset>201044</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <overlap_lowest_error>True</overlap_lowest_error>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
@@ -146,7 +144,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>9.74</norm_lambda_requested>
    <norm_dataset>201045</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <overlap_lowest_error>True</overlap_lowest_error>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
@@ -197,7 +194,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>7.043</norm_lambda_requested>
    <norm_dataset>201048</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <overlap_lowest_error>True</overlap_lowest_error>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
@@ -248,7 +244,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>201051</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <overlap_lowest_error>True</overlap_lowest_error>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
@@ -299,7 +294,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>201051</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <overlap_lowest_error>True</overlap_lowest_error>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
@@ -350,7 +344,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>201051</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <overlap_lowest_error>True</overlap_lowest_error>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>

--- a/reduction/data/template_fbck.xml
+++ b/reduction/data/template_fbck.xml
@@ -45,7 +45,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>15.0</norm_lambda_requested>
    <norm_dataset>198399</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -93,7 +92,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>12.386</norm_lambda_requested>
    <norm_dataset>198400</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -141,7 +139,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>9.74</norm_lambda_requested>
    <norm_dataset>198401</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -189,7 +186,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>7.043</norm_lambda_requested>
    <norm_dataset>198402</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -237,7 +233,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -285,7 +280,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -333,7 +327,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -381,7 +374,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>

--- a/reduction/data/template_short_nobck.xml
+++ b/reduction/data/template_short_nobck.xml
@@ -41,7 +41,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>15.0</norm_lambda_requested>
    <norm_dataset>198399</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -88,7 +87,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>12.386</norm_lambda_requested>
    <norm_dataset>198400</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -135,7 +133,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>9.74</norm_lambda_requested>
    <norm_dataset>198401</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -182,7 +179,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>7.043</norm_lambda_requested>
    <norm_dataset>198402</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -229,7 +225,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -276,7 +271,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -323,7 +317,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
@@ -370,7 +363,6 @@
    <norm_to_back_pixels>150</norm_to_back_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>198403</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset>0.0</angle_offset>
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>

--- a/reduction/data/template_with_const_q_true.xml
+++ b/reduction/data/template_with_const_q_true.xml
@@ -48,7 +48,7 @@
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
    <q_min>0.005</q_min>
-   <const_q>False</const_q>
+   <const_q>True</const_q>
    <scaling_factor_flag>True</scaling_factor_flag>
    <scaling_factor_file>data/sf_197912_Si_auto.cfg</scaling_factor_file>
    <incident_medium_list>Si</incident_medium_list>
@@ -95,7 +95,7 @@
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
    <q_min>0.005</q_min>
-   <const_q>False</const_q>
+   <const_q>True</const_q>
    <scaling_factor_flag>True</scaling_factor_flag>
    <scaling_factor_file>data/sf_197912_Si_auto.cfg</scaling_factor_file>
    <incident_medium_list>Si</incident_medium_list>
@@ -142,7 +142,7 @@
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
    <q_min>0.005</q_min>
-   <const_q>False</const_q>
+   <const_q>True</const_q>
    <scaling_factor_flag>True</scaling_factor_flag>
    <scaling_factor_file>data/sf_197912_Si_auto.cfg</scaling_factor_file>
    <incident_medium_list>Si</incident_medium_list>
@@ -189,7 +189,7 @@
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
    <q_min>0.005</q_min>
-   <const_q>False</const_q>
+   <const_q>True</const_q>
    <scaling_factor_flag>True</scaling_factor_flag>
    <scaling_factor_file>data/sf_197912_Si_auto.cfg</scaling_factor_file>
    <incident_medium_list>Si</incident_medium_list>
@@ -236,7 +236,7 @@
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
    <q_min>0.005</q_min>
-   <const_q>False</const_q>
+   <const_q>True</const_q>
    <scaling_factor_flag>True</scaling_factor_flag>
    <scaling_factor_file>data/sf_197912_Si_auto.cfg</scaling_factor_file>
    <incident_medium_list>Si</incident_medium_list>
@@ -283,7 +283,7 @@
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
    <q_min>0.005</q_min>
-   <const_q>False</const_q>
+   <const_q>True</const_q>
    <scaling_factor_flag>True</scaling_factor_flag>
    <scaling_factor_file>data/sf_197912_Si_auto.cfg</scaling_factor_file>
    <incident_medium_list>Si</incident_medium_list>
@@ -330,7 +330,7 @@
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
    <q_min>0.005</q_min>
-   <const_q>False</const_q>
+   <const_q>True</const_q>
    <scaling_factor_flag>True</scaling_factor_flag>
    <scaling_factor_file>data/sf_197912_Si_auto.cfg</scaling_factor_file>
    <incident_medium_list>Si</incident_medium_list>
@@ -377,7 +377,7 @@
    <angle_offset_error>0.0</angle_offset_error>
    <q_step>0.02</q_step>
    <q_min>0.005</q_min>
-   <const_q>False</const_q>
+   <const_q>True</const_q>
    <scaling_factor_flag>True</scaling_factor_flag>
    <scaling_factor_file>data/sf_197912_Si_auto.cfg</scaling_factor_file>
    <incident_medium_list>Si</incident_medium_list>

--- a/reduction/data/template_with_instrument_settings.xml
+++ b/reduction/data/template_with_instrument_settings.xml
@@ -45,7 +45,6 @@
    <norm_to_back2_pixels>0</norm_to_back2_pixels>
    <norm_lambda_requested>15.0</norm_lambda_requested>
    <norm_dataset>188230</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset> 0 </angle_offset>
    <angle_offset_error> 0 </angle_offset_error>
    <q_step>0.02</q_step>
@@ -111,7 +110,6 @@
    <norm_to_back2_pixels>0</norm_to_back2_pixels>
    <norm_lambda_requested>12.386</norm_lambda_requested>
    <norm_dataset>188231</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset> 0 </angle_offset>
    <angle_offset_error> 0 </angle_offset_error>
    <q_step>0.02</q_step>
@@ -177,7 +175,6 @@
    <norm_to_back2_pixels>0</norm_to_back2_pixels>
    <norm_lambda_requested>9.74</norm_lambda_requested>
    <norm_dataset>188232</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset> 0 </angle_offset>
    <angle_offset_error> 0 </angle_offset_error>
    <q_step>0.02</q_step>
@@ -243,7 +240,6 @@
    <norm_to_back2_pixels>0</norm_to_back2_pixels>
    <norm_lambda_requested>7.043</norm_lambda_requested>
    <norm_dataset>188233</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset> 0 </angle_offset>
    <angle_offset_error> 0 </angle_offset_error>
    <q_step>0.02</q_step>
@@ -309,7 +305,6 @@
    <norm_to_back2_pixels>0</norm_to_back2_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>188234</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset> 0 </angle_offset>
    <angle_offset_error> 0 </angle_offset_error>
    <q_step>0.02</q_step>
@@ -375,7 +370,6 @@
    <norm_to_back2_pixels>0</norm_to_back2_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>188234</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset> 0 </angle_offset>
    <angle_offset_error> 0 </angle_offset_error>
    <q_step>0.02</q_step>
@@ -441,7 +435,6 @@
    <norm_to_back2_pixels>0</norm_to_back2_pixels>
    <norm_lambda_requested>4.25</norm_lambda_requested>
    <norm_dataset>188234</norm_dataset>
-   <auto_q_binning>False</auto_q_binning>
    <angle_offset> 0 </angle_offset>
    <angle_offset_error> 0 </angle_offset_error>
    <q_step>0.02</q_step>

--- a/reduction/lr_reduction/reduction_template_reader.py
+++ b/reduction/lr_reduction/reduction_template_reader.py
@@ -56,7 +56,7 @@ class ReductionParameters:
         # Q range
         self.q_min = 0.001
         self.q_step = 0.001
-        self.auto_q_binning = False
+        self.const_q = False
 
         # Scattering angle
         self.tthd_value = 0
@@ -160,7 +160,7 @@ class ReductionParameters:
         _xml += "<post_cut>%s</post_cut>\n" % str(self.post_cut)
         _xml += "<q_min>%s</q_min>\n" % str(self.q_min)
         _xml += "<q_step>%s</q_step>\n" % str(self.q_step)
-        _xml += "<auto_q_binning>%s</auto_q_binning>\n" % str(self.auto_q_binning)
+        _xml += "<const_q>%s</const_q>\n" % str(self.const_q)
 
         # Angle offset
         _xml += "<angle_offset>%s</angle_offset>\n" % str(self.angle_offset)
@@ -283,7 +283,7 @@ class ReductionParameters:
         self.post_cut = getIntElement(instrument_dom, "post_cut", default=self.post_cut)
         self.q_min = getFloatElement(instrument_dom, "q_min", default=self.q_min)
         self.q_step = getFloatElement(instrument_dom, "q_step", default=self.q_step)
-        self.auto_q_binning = getBoolElement(instrument_dom, "auto_q_binning", default=False)
+        self.const_q = getBoolElement(instrument_dom, "const_q", default=False)
 
         # Angle offset
         self.angle_offset = getFloatElement(instrument_dom, "angle_offset", default=self.angle_offset)

--- a/reduction/lr_reduction/template.py
+++ b/reduction/lr_reduction/template.py
@@ -237,6 +237,10 @@ def process_from_template_ws(
 
     peak_center = (peak[0] + peak[1]) / 2.0
 
+    # Use template const_q if q_summing not explicitly provided
+    if q_summing is None:
+        q_summing = template_data.const_q
+
     # Fit the reflected beam position, which may not be in the middle and is
     # used in the q-summing calculation
     if q_summing:
@@ -247,9 +251,6 @@ def process_from_template_ws(
         peak_center, sc_width, _ = peak_finding.fit_signal_flat_bck(_x, _y, x_min=x_min,
                                                                     x_max=x_max, center=peak_center, sigma=3.0)
         print("Peak center: %g" % peak_center)
-
-    if q_summing is None:
-        q_summing = template_data.const_q
 
 
     if template_data.data_x_range_flag:

--- a/reduction/lr_reduction/template.py
+++ b/reduction/lr_reduction/template.py
@@ -128,11 +128,12 @@ def scaling_factor(scaling_factor_file, workspace, match_slit_width=True):
 
 
 def process_from_template(
-    run_number, template_path, q_summing=False, normalize=True, tof_weighted=False, bck_in_q=False,
+    run_number, template_path, q_summing=None, normalize=True, tof_weighted=False, bck_in_q=False,
     clean=False, info=False
     ):
     """
     The clean option removes leading zeros and the drop when doing q-summing
+    @param q_summing: If None, the template setting will be used; if True/False, override the template
     """
     # For backward compatibility, consider the case of a list of run numbers to be added
     if "," in str(run_number):
@@ -158,6 +159,9 @@ def process_from_template_ws(
     theta_value=None,
     ws_db=None,
 ):
+    """
+    @param q_summing: If None, the template setting will be used; if True/False, override the template
+    """
     # Get the sequence number
     sequence_number = 1
     if ws_sc.getRun().hasProperty("sequence_number"):

--- a/reduction/lr_reduction/template.py
+++ b/reduction/lr_reduction/template.py
@@ -149,7 +149,7 @@ def process_from_template(
 def process_from_template_ws(
     ws_sc,
     template_data,
-    q_summing=False,
+    q_summing=None,
     tof_weighted=False,
     bck_in_q=False,
     clean=False,
@@ -248,6 +248,10 @@ def process_from_template_ws(
                                                                     x_max=x_max, center=peak_center, sigma=3.0)
         print("Peak center: %g" % peak_center)
 
+    if q_summing is None:
+        q_summing = template_data.const_q
+
+
     if template_data.data_x_range_flag:
         low_res = template_data.data_x_range
     else:
@@ -303,6 +307,9 @@ def process_from_template_ws(
     qz, refl, d_refl = event_refl.specular(
         q_summing=q_summing, tof_weighted=tof_weighted, bck_in_q=bck_in_q, clean=clean, normalize=normalize
     )
+    print(f"qz: {qz}")
+    print(f"refl: {refl}")
+    print(f"d_refl: {d_refl}")
     qz_mid = (qz[:-1] + qz[1:]) / 2.0
 
     # When using composite direct beam, we don't need a scaling

--- a/reduction/lr_reduction/template.py
+++ b/reduction/lr_reduction/template.py
@@ -307,9 +307,6 @@ def process_from_template_ws(
     qz, refl, d_refl = event_refl.specular(
         q_summing=q_summing, tof_weighted=tof_weighted, bck_in_q=bck_in_q, clean=clean, normalize=normalize
     )
-    print(f"qz: {qz}")
-    print(f"refl: {refl}")
-    print(f"d_refl: {d_refl}")
     qz_mid = (qz[:-1] + qz[1:]) / 2.0
 
     # When using composite direct beam, we don't need a scaling

--- a/reduction/lr_reduction/time_resolved.py
+++ b/reduction/lr_reduction/time_resolved.py
@@ -110,7 +110,7 @@ def reduce_30Hz_slices(
     scan_index=1,
     create_plot=True,
     template_reference=None,
-    q_summing=None, # noqa ARG001
+    q_summing=None,
 ):
     meas_ws_30Hz = api.LoadEventNexus("REF_L_%s" % meas_run_30Hz)
 
@@ -124,7 +124,7 @@ def reduce_30Hz_slices(
         scan_index=scan_index,
         create_plot=create_plot,
         template_reference=template_reference,
-        q_summing=None,
+        q_summing=q_summing,
     )
 
 

--- a/reduction/lr_reduction/time_resolved.py
+++ b/reduction/lr_reduction/time_resolved.py
@@ -26,7 +26,7 @@ def reduce_30Hz_from_ws(
     template_data,
     scan_index=1,  # noqa ARG001
     template_reference=None,
-    q_summing=False,
+    q_summing=None,
 ):
     """
     Perform 30Hz reduction
@@ -110,7 +110,7 @@ def reduce_30Hz_slices(
     scan_index=1,
     create_plot=True,
     template_reference=None,
-    q_summing=False, # noqa ARG001
+    q_summing=None, # noqa ARG001
 ):
     meas_ws_30Hz = api.LoadEventNexus("REF_L_%s" % meas_run_30Hz)
 
@@ -124,7 +124,7 @@ def reduce_30Hz_slices(
         scan_index=scan_index,
         create_plot=create_plot,
         template_reference=template_reference,
-        q_summing=False,
+        q_summing=None,
     )
 
 
@@ -146,7 +146,7 @@ def reduce_30Hz_slices_ws(
     scan_index=1,
     create_plot=True,
     template_reference=None,
-    q_summing=False,
+    q_summing=None,
 ):
     """
     Perform 30Hz reduction

--- a/reduction/lr_reduction/workflow.py
+++ b/reduction/lr_reduction/workflow.py
@@ -12,7 +12,7 @@ from . import event_reduction, output, reduction_template_reader, template
 
 
 def reduce(
-    ws, template_file, output_dir, average_overlap=False, theta_offset: float | None = 0, q_summing=False, bck_in_q=False, is_live=False
+    ws, template_file, output_dir, average_overlap=False, theta_offset: float | None = 0, q_summing=None, bck_in_q=False, is_live=False
 ):
     """
     Function called by reduce_REFL.py, which lives in /SNS/REF_L/shared/autoreduce
@@ -26,7 +26,7 @@ def reduce(
     average_overlap : bool
         If True, the overlapping points will be averaged
     q_summing : bool
-        If True, constant-Q binning will be used
+        If None, the template setting will be used; if True/False, override the template
     bck_in_q : bool
         If True, and constant-Q binning is used, the background will be estimated
         along constant-Q lines rather than along TOF/pixel boundaries.
@@ -368,7 +368,7 @@ def reduce_explorer(ws, ws_db, theta_pv=None, center_pixel=145, db_center_pixel=
     )
 
     # R(Q)
-    qz, refl, d_refl = event_refl.specular(q_summing=False, tof_weighted=False, bck_in_q=False, clean=False, normalize=True)
+    qz, refl, d_refl = event_refl.specular(q_summing=None, tof_weighted=False, bck_in_q=False, clean=False, normalize=True)
     qz_mid = (qz[:-1] + qz[1:]) / 2.0
 
     return qz_mid, refl, d_refl

--- a/reduction/tests/test_reduction.py
+++ b/reduction/tests/test_reduction.py
@@ -88,7 +88,7 @@ def test_q_summing(nexus_dir):
 
 def test_q_summing_as_option(nexus_dir):
     """
-    Test Q summing process
+    Test Q summing with and without supplying q_summing option
     """
     template_path = "data/template.xml"
     template.read_template(template_path, 7)

--- a/reduction/tests/test_reduction.py
+++ b/reduction/tests/test_reduction.py
@@ -1,6 +1,7 @@
 # standard imports
 import os
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 
 # third-party imports
 import mantid
@@ -80,6 +81,38 @@ def test_q_summing(nexus_dir):
     # as part of future regridding but not typically used for lowest angle and check
     # agreement excluding these lowest points for now. (Graph shows change.)
     assert np.fabs(np.mean(refl[3:] - refl0[2:])) < 1e-6
+
+    # Cleanup
+    output_dir = "data/"
+    cleanup_partial_files(output_dir, range(198409, 198417))
+
+def test_q_summing_as_option(nexus_dir):
+    """
+    Test Q summing process
+    """
+    template_path = "data/template.xml"
+    template.read_template(template_path, 7)
+    with amend_config(data_dir=nexus_dir):
+        ws_sc = mtd_api.Load("REF_L_%s" % 198415)
+    qz_mid0, refl0, _, meta_data = template.process_from_template_ws(ws_sc, template_path, info=True)
+    with patch.object(event_reduction.EventReflectivity, 'specular') as mock_specular:
+        mock_specular.return_value = (np.array([1, 2, 3]), np.array([0.1, 0.2]), np.array([0.01, 0.02]))
+        qz_mid, refl, d_refl = template.process_from_template_ws(ws_sc, template_path)
+        mock_specular.assert_called_once()
+        # Check the keyword arguments passed to specular
+        call_kwargs = mock_specular.call_args[1]
+        assert call_kwargs['q_summing'] == False
+
+    with patch.object(event_reduction.EventReflectivity, 'specular') as mock_specular:
+        mock_specular.return_value = (np.array([1, 2, 3]), np.array([0.1, 0.2]), np.array([0.01, 0.02]))
+        # Now try with Q summing, which should have similar results
+        qz_mid, refl, _, meta_data = template.process_from_template_ws(ws_sc, template_path, tof_weighted=True,
+                                                                   info=True, q_summing=True)
+        mock_specular.assert_called_once()
+        call_kwargs = mock_specular.call_args[1]
+        assert call_kwargs['q_summing'] == True
+
+
 
     # Cleanup
     output_dir = "data/"

--- a/reduction/tests/test_reduction.py
+++ b/reduction/tests/test_reduction.py
@@ -1,7 +1,7 @@
 # standard imports
 import os
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 # third-party imports
 import mantid


### PR DESCRIPTION
## Description of work:

The logic for using q_binning flag in process_from_template_ws() was updated so that if no q_binning flag was supplied, it would be set from the const_q from within the template. I also removed all references to auto_q_binning as it was not being used anywhere. 

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [x] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [13218](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=13218)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
Make sure process_from_template_ws() now functions as expected

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
