### PR TITLE
Additional diagnostics plots for autoreduction

### DIFF
--- a/docs/api/lr_reduction.rst
+++ b/docs/api/lr_reduction.rst
@@ -15,6 +15,14 @@ lr_reduction.background
    :undoc-members:
    :show-inheritance:
 
+lr_reduction.data_info
+----------------------
+
+.. automodule:: lr_reduction.data_info
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 lr_reduction.event_reduction
 ----------------------------
 
@@ -91,6 +99,14 @@ lr_reduction.utils
 ------------------
 
 .. automodule:: lr_reduction.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+lr_reduction.web_report
+-----------------------
+
+.. automodule:: lr_reduction.web_report
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,7 @@ autodoc_mock_imports = [
     "mantid.plots.plotfunctions",
     "mantid.plots.datafunctions",
     "mantid.plots.utility",
+    "requests",
 ]
 
 master_doc = "index"
@@ -61,6 +62,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
     "mantid": ("https://docs.mantidproject.org/nightly/", None),
+    "requests": ("https://requests.readthedocs.io/en/latest/", None),
 }
 intersphinx_disabled_domains = ["std"]
 

--- a/docs/user/workflow.rst
+++ b/docs/user/workflow.rst
@@ -55,7 +55,7 @@ Reduction workflow
 ------------------
 
 The main reduction workflow, which will extract specular reflectivity from a data file given a
-reduction template, is found in the `workflow` module. This workflow will is the one performed
+reduction template, is found in the ``workflow`` module. This workflow is the one performed
 by the automated reduction system at BL4B:
 
 - It will extract the correct reduction parameters from the provided template
@@ -83,3 +83,15 @@ Once you have a template, you can simply do:
     workflow.reduce(ws, template_file, output_dir)
 
 This will produce output files in the specified output directory.
+
+Autoreduction workflow
+----------------------
+
+The autoreduction script is found in ``src/lr_autoreduce/reduce_REF_L.py``. On the analysis cluster,
+the autoreduction can be run manually inside the Pixi environment `lr_reduction`:
+
+.. code-block:: bash
+
+    $ nsd-pixi-shell.sh lr_reduction
+    (lr_reduction)$ mkdir output
+    (lr_reduction)$ python src/lr_autoreduce/reduce_REF_L.py /SNS/REF_L/IPTS-35571/nexus/REF_L_223298.nxs.h5 output/ --no_publish

--- a/docs/user/workflow.rst
+++ b/docs/user/workflow.rst
@@ -88,10 +88,13 @@ Autoreduction workflow
 ----------------------
 
 The autoreduction script is found in ``src/lr_autoreduce/reduce_REF_L.py``. On the analysis cluster,
-the autoreduction can be run manually inside the Pixi environment `lr_reduction`:
+the autoreduction can be run manually inside the Pixi environment ``lr_reduction``:
 
 .. code-block:: bash
 
     $ nsd-pixi-shell.sh lr_reduction
     (lr_reduction)$ mkdir output
     (lr_reduction)$ python src/lr_autoreduce/reduce_REF_L.py /SNS/REF_L/IPTS-35571/nexus/REF_L_223298.nxs.h5 output/ --no_publish
+This will reduce the specified data file and write the output to the ``output`` folder. The ``--no_publish``
+option prevents the script from trying to publish the HTML report to the web monitor. The HTML report can still
+be found in the output folder.

--- a/pixi.lock
+++ b/pixi.lock
@@ -3456,8 +3456,8 @@ packages:
   timestamp: 1753035921043
 - pypi: ./
   name: lr-reduction
-  version: 2.8.0.dev10
-  sha256: 451310d80c508dddf1983dce1c8334028ab064f55631e824e7880a2a3d5d809c
+  version: 2.8.0.dev21
+  sha256: 7367f6223125e9d2b9d3cdadfaeef734a15fb6aa536bd8fe0435443f4574f4cb
   requires_python: '>=3.11'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ markers = [
   "datarepo: mark a test as using LiquidsReflectometer-data repository",
   "scripts: mark a test as a script that should be run manually",
 ]
+addopts = "--import-mode=importlib"  # to allow a unit test and integration test with the same module name
 
 #########
 #  RUFF

--- a/src/lr_autoreduce/reduce_REF_L.py
+++ b/src/lr_autoreduce/reduce_REF_L.py
@@ -134,9 +134,11 @@ def autoreduce(
         # Generate simple report
         report_sections = generate_report_sections(ws, template_file)
         report = assemble_report(None, report_sections)
-    else:
+    elif data_type == DataType.UNKNOWN:
         logger.notice(f"Data type {data_type} not supported for autoreduction.")
         return
+    else:
+        raise ValueError(f"Unhandled data type: {data_type}")
 
     # Save to disk and (optionally) upload the HTML report
     match = re.search(r'REF_L_(\d+)', events_file)

--- a/src/lr_reduction/data_info.py
+++ b/src/lr_reduction/data_info.py
@@ -37,7 +37,7 @@ class DataType(IntEnum):
         value = cls.REFLECTED_BEAM
         try:
             # Determine if direct beam based on geometry
-            if (sample_logs["BL4B:CS:Mode:Coordinates"] == 0 or  # This is a new log for earth-centered
+            if (("BL4B:CS:Mode:Coordinates" in sample_logs and sample_logs["BL4B:CS:Mode:Coordinates"] == 0) or  # This is a new log for earth-centered
                     sample_logs["BL4B:CS:ExpPl:OperatingMode"] == "Free Liquid"):  # This is backward compatibility from before the new log value
                 # Earth-centered coordinate system
                 thi = sample_logs["thi"]

--- a/src/lr_reduction/data_info.py
+++ b/src/lr_reduction/data_info.py
@@ -1,0 +1,49 @@
+"""
+Meta-data information for LR reduction
+"""
+
+from enum import IntEnum
+
+import numpy as np
+
+from lr_reduction.mantid_utils import SampleLogValues
+from lr_reduction.typing import MantidWorkspace
+
+
+class DataType(IntEnum):
+    """
+    Enum to represent the typical types of data for the Liquids Reflectometer
+
+    Attributes:
+        UNKNOWN (int): Represents unknown data TYPE, usually because of low neutron count in the associated run.
+        REFLECTED_BEAM (int): Represents reflected beam data.
+        DIRECT_BEAM (int): Represents direct beam data.
+    """
+
+    UNKNOWN = -1
+    REFLECTED_BEAM = 0
+    DIRECT_BEAM = 1
+
+    @classmethod
+    def from_workspace(cls, input_workspace: MantidWorkspace):
+        """
+        Determine the data type from the given workspace.
+
+        Currently, the 'data_type' property is not set automatically in
+        the DAS, therefore, use the incoming angle and scattering angle
+        to determine the data type.
+        """
+        sample_logs = SampleLogValues(input_workspace)
+        try:
+            tthd = sample_logs["tthd"]
+            ths = sample_logs["ths"]
+            if np.fabs(tthd) < 0.001 and np.fabs(ths) < 0.001:
+                value = cls.DIRECT_BEAM
+            else:
+                value = cls.REFLECTED_BEAM
+        except Exception:  # noqa E722
+            value = cls.REFLECTED_BEAM  # missing logs, assume reflected beam
+        return value
+
+    def __str__(self):
+        return self.name

--- a/src/lr_reduction/data_info.py
+++ b/src/lr_reduction/data_info.py
@@ -36,13 +36,13 @@ class DataType(IntEnum):
         sample_logs = SampleLogValues(input_workspace)
         value = cls.REFLECTED_BEAM
         try:
-            # Determine if direct beam based on geometry
+            # Determine whether this is a direct beam based on the geometry
             if (("BL4B:CS:Mode:Coordinates" in sample_logs and sample_logs["BL4B:CS:Mode:Coordinates"] == 0) or  # This is a new log for earth-centered
                     sample_logs["BL4B:CS:ExpPl:OperatingMode"] == "Free Liquid"):  # This is backward compatibility from before the new log value
                 # Earth-centered coordinate system
                 thi = sample_logs["thi"]
                 tthd = sample_logs["tthd"]
-                if np.isclose(thi, tthd) and np.fabs(thi) < 0.01:
+                if np.isclose(thi, tthd, atol=0.01):
                     value = cls.DIRECT_BEAM
             else:
                 # Beam-centered coordinate system

--- a/src/lr_reduction/data_info.py
+++ b/src/lr_reduction/data_info.py
@@ -5,6 +5,7 @@ Meta-data information for LR reduction
 from enum import IntEnum
 
 import numpy as np
+from mantid.simpleapi import logger
 
 from lr_reduction.mantid_utils import SampleLogValues
 from lr_reduction.typing import MantidWorkspace
@@ -38,7 +39,7 @@ class DataType(IntEnum):
         try:
             # Determine whether this is a direct beam based on the geometry
             if (("BL4B:CS:Mode:Coordinates" in sample_logs and sample_logs["BL4B:CS:Mode:Coordinates"] == 0) or  # This is a new log for earth-centered
-                    sample_logs["BL4B:CS:ExpPl:OperatingMode"] == "Free Liquid"):  # This is backward compatibility from before the new log value
+                    sample_logs["BL4B:CS:ExpPl:OperatingMode"] == "Free Liquid"):  # This is for backward compatibility from before the new log value
                 # Earth-centered coordinate system
                 thi = sample_logs["thi"]
                 tthd = sample_logs["tthd"]
@@ -50,8 +51,8 @@ class DataType(IntEnum):
                 tthd = sample_logs["tthd"]
                 if np.fabs(tthd) < 0.001 and np.fabs(ths) < 0.001:
                     value = cls.DIRECT_BEAM
-        except Exception:  # noqa E722
-            pass  # missing logs, assume reflected beam
+        except KeyError as e:
+            logger.warning(f"Missing sample log {e}, assuming reflected beam")
         return value
 
     def __str__(self):

--- a/src/lr_reduction/event_reduction.py
+++ b/src/lr_reduction/event_reduction.py
@@ -578,6 +578,7 @@ class EventReflectivity:
             sequence_id=sequence_id,
             q_summing=self.q_summing,
             specular_pixel=self.specular_pixel,
+            use_functional_bck=self.use_functional_bck,  # whether functional background was used
         )
 
     def specular(self, q_summing=False, tof_weighted=False, bck_in_q=False, clean=False, normalize=True):

--- a/src/lr_reduction/event_reduction.py
+++ b/src/lr_reduction/event_reduction.py
@@ -577,6 +577,7 @@ class EventReflectivity:
             sequence_number=sequence_number,
             sequence_id=sequence_id,
             q_summing=self.q_summing,
+            specular_pixel=self.specular_pixel,
         )
 
     def specular(self, q_summing=False, tof_weighted=False, bck_in_q=False, clean=False, normalize=True):

--- a/src/lr_reduction/output.py
+++ b/src/lr_reduction/output.py
@@ -208,12 +208,15 @@ class RunCollection:
             HTML div containing the combined reflectivity curve plot
         """
         refl_curves = []
+        run_names = []
 
         for item in self.collection:
             refl_curves.append([item["q"], item["r"], item["dr"], item["dq"]])
+            run_names.append(f"Run: {item['info']['run_number']}")
 
-        # run_number is only used when publish=True
-        return plot1d(run_number="dummy_run", data_list=refl_curves, instrument='REF_L',
+        # run_number parameter is only used when publish=True
+        return plot1d(run_number="dummy_run", data_list=refl_curves, data_names=run_names,
+                      instrument='REF_L',
                       x_title=u"Q (1/A)", x_log=True,
                       y_title="Reflectivity", y_log=True, show_dx=False, publish=False)
 

--- a/src/lr_reduction/output.py
+++ b/src/lr_reduction/output.py
@@ -200,7 +200,7 @@ class RunCollection:
 
     def plot(self):
         """
-        Plot the collection of runs
+        Plot the combined reflectivity curve for a collection of runs
 
         Returns
         -------

--- a/src/lr_reduction/output.py
+++ b/src/lr_reduction/output.py
@@ -5,6 +5,7 @@ Write R(q) output
 import json
 
 import numpy as np
+from plot_publisher import plot1d
 
 from . import __version__ as VERSION
 
@@ -196,6 +197,26 @@ class RunCollection:
         """
         _q, _r, _dr, _dq, _meta = read_file(file_path)
         self.add(_q, _r, _dr, _meta, dq=_dq)
+
+    def plot(self):
+        """
+        Plot the collection of runs
+
+        Returns
+        -------
+        str
+            HTML div containing the combined reflectivity curve plot
+        """
+        refl_curves = []
+
+        for item in self.collection:
+            for i in range(len(item["q"])):
+                refl_curves.append([item["q"][i], item["r"][i], item["dr"][i], item["dq"][i]])
+
+        # run_number is only used when publish=True
+        return plot1d(run_number="dummy_run", data_list=refl_curves, instrument='REF_L',
+                      x_title=u"Q (1/A)", x_log=True,
+                      y_title="Reflectivity", y_log=True, show_dx=False, publish=False)
 
 
 def read_file(file_path):

--- a/src/lr_reduction/output.py
+++ b/src/lr_reduction/output.py
@@ -210,8 +210,7 @@ class RunCollection:
         refl_curves = []
 
         for item in self.collection:
-            for i in range(len(item["q"])):
-                refl_curves.append([item["q"][i], item["r"][i], item["dr"][i], item["dq"][i]])
+            refl_curves.append([item["q"], item["r"], item["dr"], item["dq"]])
 
         # run_number is only used when publish=True
         return plot1d(run_number="dummy_run", data_list=refl_curves, instrument='REF_L',

--- a/src/lr_reduction/template.py
+++ b/src/lr_reduction/template.py
@@ -8,10 +8,12 @@ from pathlib import Path
 
 import mantid.simpleapi as api
 import numpy as np
+from mantid.simpleapi import logger
 
 from lr_reduction import event_reduction, peak_finding, reduction_template_reader
 from lr_reduction.instrument_settings import InstrumentSettings
 from lr_reduction.reduction_template_reader import ReductionParameters
+from lr_reduction.typing import MantidWorkspace
 
 TOLERANCE = 0.07
 OUTPUT_NORM_DATA = False
@@ -191,18 +193,20 @@ def process_from_template(
 
 
 def process_from_template_ws(
-    ws_sc,
-    template_data,
-    q_summing=None,
-    tof_weighted=False,
-    bck_in_q=False,
-    clean=False,
-    info=False,
-    normalize=True,
-    theta_value=None,
-    ws_db=None,
+    ws_sc: MantidWorkspace,
+    template_data: str | ReductionParameters,
+    q_summing: bool = None,
+    tof_weighted: bool = False,
+    bck_in_q: bool = False,
+    clean: bool = False,
+    info: bool = False,
+    normalize: bool = True,
+    theta_value: float = None,
+    ws_db: MantidWorkspace = None,
 ):
     """
+    Reduce a Mantid workspace using the given template
+
     @param q_summing: If None, the template setting will be used; if True/False, override the template
     """
     # Get the sequence number
@@ -270,7 +274,7 @@ def process_from_template_ws(
         theta += template_data.angle_offset * np.pi / 180.0
 
     theta_degrees = theta * 180 / np.pi
-    print(
+    logger.notice(
         "wl=%g; ths=%g; thi=%g; offset=%g; theta used=%g"
         % (_wl, ths_value, thi_value, template_data.angle_offset, theta_degrees)
     )
@@ -289,6 +293,9 @@ def process_from_template_ws(
     # Use template const_q if q_summing not explicitly provided
     if q_summing is None:
         q_summing = template_data.const_q
+        logger.notice(f"Using template const_q: {q_summing}")
+    else:
+        logger.notice(f"Using const_q from input parameter: {q_summing}")
 
     # Fit the reflected beam position, which may not be in the middle and is
     # used in the q-summing calculation
@@ -300,7 +307,7 @@ def process_from_template_ws(
         peak_center, sc_width, _ = peak_finding.fit_signal_flat_bck(
             _x, _y, x_min=x_min, x_max=x_max, center=peak_center, sigma=3.0
         )
-        print("Peak center: %g" % peak_center)
+        logger.notice("Peak center: %g" % peak_center)
 
     if template_data.data_x_range_flag:
         low_res = template_data.data_x_range
@@ -368,12 +375,12 @@ def process_from_template_ws(
             a = ws_db.getRun()[scaling_factor_PV].value[0] ** 2
         else:
             a = ws_db.getRun()[scaling_factor_PV].value[0]
-        print("Composite scaling factor: %s" % a)
+        logger.notice("Composite scaling factor: %s" % a)
         d_refl /= a
         refl /= a
         b = err_a = err_b = 0
     elif normalize and template_data.scaling_factor_flag:
-        print("Normalization options: %s %s" % (normalize, template_data.scaling_factor_flag))
+        logger.notice("Normalization options: %s %s" % (normalize, template_data.scaling_factor_flag))
         # Get the scaling factors
         a, b, err_a, err_b = scaling_factor(template_data.scaling_factor_file, ws_sc)
         _tof = 4 * np.pi * np.sin(event_refl.theta) * event_refl.constant / qz
@@ -383,7 +390,7 @@ def process_from_template_ws(
         d_refl = np.sqrt(d_refl**2 / a_q**2 + refl**2 * d_a_q**2 / a_q**4)
         refl /= a_q
     else:
-        print("Skipping scaling factor")
+        logger.notice("Skipping scaling factor")
         a = b = 1
         err_a = err_b = 0
 

--- a/src/lr_reduction/template.py
+++ b/src/lr_reduction/template.py
@@ -195,14 +195,14 @@ def process_from_template(
 def process_from_template_ws(
     ws_sc: MantidWorkspace,
     template_data: str | ReductionParameters,
-    q_summing: bool = None,
+    q_summing: bool | None = None,
     tof_weighted: bool = False,
     bck_in_q: bool = False,
     clean: bool = False,
     info: bool = False,
     normalize: bool = True,
-    theta_value: float = None,
-    ws_db: MantidWorkspace = None,
+    theta_value: float | None = None,
+    ws_db: MantidWorkspace | None = None,
 ):
     """
     Reduce a Mantid workspace using the given template

--- a/src/lr_reduction/web_report.py
+++ b/src/lr_reduction/web_report.py
@@ -1,0 +1,921 @@
+"""
+Report class used to populate the web monitor
+"""
+
+import math
+import sys
+import time
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import plotly.graph_objs as go
+import plotly.offline as pyo
+import requests
+from mantid.simpleapi import Integration, Rebin, RefRoi, SumSpectra, Transpose, logger
+from plot_publisher import publish_plot
+
+from lr_reduction import template
+from lr_reduction.data_info import DataType
+from lr_reduction.mantid_utils import SampleLogValues
+from lr_reduction.reduction_template_reader import ReductionParameters
+from lr_reduction.typing import MantidWorkspace
+
+
+def html_wrapper(report: Union[str, None]) -> str:
+    """Wraps a report (set of <dvi> elements) in a complete HTML document
+
+    Adds the javascript engine (PlotLy.js) address, HTML head, and body tags.
+
+    Parameters
+    ----------
+    report : str
+        The HTML content to be wrapped. This should contain on or more <div> elements and possibly
+        summary <table> elements.
+
+    Returns
+    -------
+    str
+        A complete HTML document as a string, with the provided report content embedded within the body.
+    """
+    js_version = pyo.get_plotlyjs_version()
+    url = f"https://cdn.plot.ly/plotly-{js_version}.js"
+    try:
+        response = requests.head(url, timeout=5)
+        assert response.status_code == 200
+    except (requests.RequestException, AssertionError):
+        logger.error(f"Plotly.js version {js_version} not found, using version 3.0.0 instead")
+        url = "https://cdn.plot.ly/plotly-3.0.0.js"
+
+    prefix = f"""<!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Plotly Chart</title>
+        <script src="{url}"></script>
+    </head>
+    <body>
+
+    """
+    suffix = """
+
+    </body>
+    </html>
+    """
+    report = "" if report is None else report
+    return prefix + report + suffix  # allow for report being `None`
+
+
+def _concatenate_reports(reports: List[str]) -> str:
+    if isinstance(reports, (list, tuple)):
+        composite = "\n".join([str(report) for report in reports])
+    else:
+        composite = str(reports)
+    return composite
+
+
+def save_report(html_report: Union[str, List[str]], report_file: str):
+    """Save report to a local file
+
+    If `html_report` contains more than one report, then merge them.
+
+    Parameters
+    ----------
+    html_report : str, List[str]
+        One or more compendium of <div> and <table> elements. Has all the information from reducing a run,
+        possibly including reports from more than one peak when the run contains many peaks. This could happen
+        if the experiment contained more than one sample, each reflecting at a different angle.
+    report_file : str
+        File path where the report will be saved as an HTML file.
+    """
+    report_composite = _concatenate_reports(html_report)
+    with open(report_file, "w", encoding="utf-8") as f:
+        f.write(html_wrapper(report_composite))
+
+
+def upload_report(html_report: Union[str, List[str]], run_number: Union[str, int]) -> Optional[requests.Response]:
+    r"""Upload report to the livedata server
+
+    If `html_report` contains more than one report, then merge them.
+
+    Parameters
+    ----------
+    html_report: str, List[str]
+        one or more compendium of <div> and <table> elements. Has all the information from reducing a run,
+        possibly including reports from more than one peak when the run contains many peaks. This could happen
+        if the experiment contained more than one sample, each reflecting at a different angle.
+    run_number: str, int
+        Run number (e.g. '123435'). Required if `publish` is True
+    report_file: Optional[str]
+        Save the report to a file. If `None` or `False`, the report will not be saved to a file.
+
+    Returns
+    -------
+    Optional[requests.Response]
+        `Response` object returned by the livedata server, or `None` if the function is unable to do find the
+        library to generate the `request.post()`
+    """
+    report_composite = _concatenate_reports(html_report)
+    return publish_plot("REF_M", run_number, files={"file": report_composite})
+
+
+def process_collection(summary_content=None, report_list=None) -> Tuple[str, str]:
+    r"""Process a collection of HTML reports into on final HTML report
+
+    Parameters
+    ----------
+        summary_content: str
+            HTML content to be displayed at the top of the report
+        report_list: List[lr_reduction.web_report.Report]
+            List of HTML contents to be appended at the bottom of the page
+        run_number: str
+            run number to associate this report with
+
+    Returns
+    -------
+    Tuple[str, str]
+        plot_html str: HTML
+        script str: python script
+    """
+    if report_list is None:
+        report_list = []
+    logger.notice("Processing... %s" % len(report_list))
+    plot_html = "<div></div>"
+    script = ""
+
+    if summary_content is not None:
+        plot_html += "<div>%s</div>\n" % summary_content
+
+    if report_list:
+        plot_html += report_list[0].report
+    for report in report_list:
+        script += report.script
+        plot_html += "<div>%s</div>\n" % report.cross_section_info
+        plot_html += "<table style='width:100%'>\n"
+        plot_html += "<tr>\n"
+        for plot in report.plots:
+            if plot is not None:
+                plot_html += "<td>%s</td>\n" % plot
+        plot_html += "</tr>\n"
+        plot_html += "</table>\n"
+        plot_html += "<hr>\n"
+
+    return plot_html, script
+
+
+class ReportGenerator:
+    """
+    Take the output of the reduction and generate diagnostics plots, and a block of meta data.
+    """
+
+    def __init__(self, workspace, template_file, meta_data, logfile=None):
+        """
+        Parameters
+        ----------
+        workspace
+        template_file
+        logfile
+        """
+        logger.notice("  - Data type: ")
+        self.workspace = workspace
+        self.sample_logs = SampleLogValues(workspace)
+        self.data_type = DataType.from_workspace(workspace)
+
+        # Get the sequence number
+        try:
+            sequence_number = self.sample_logs["sequence_number"]
+        except:  # noqa E722
+            sequence_number = 1
+        # Read template if it was passed as a file path
+        # It can be passed as a dict directly
+        if isinstance(template_file, str):
+            template_data = template.read_template(template_file, sequence_number)
+        else:
+            template_data = template_file
+        self.template_data = template_data
+        self.meta_data = meta_data
+
+        self.logfile = logfile
+        try:
+            self.number_events = workspace.getNumberEvents()
+        except:  # noqa E722
+            self.number_events = 0
+        self.plots = []
+        self.report = ""
+        self.event_count_info = ""
+
+    def generate(self):
+        if self.data_type != DataType.UNKNOWN:
+            self.log(f"  - generating report [{self.number_events}]")
+            self.report: str = generate_web_report(self.workspace, self.template_data, self.meta_data)
+            self.event_count_info = generate_event_count_info(self.workspace)
+            try:
+                self.plots = generate_plots(self.workspace, self.template_data)
+            except:  # noqa E722
+                self.log("Could not generate plots: %s" % sys.exc_info()[0])
+                logger.error("Could not generate plots: %s" % sys.exc_info()[0])
+        else:
+            logger.error("Invalid data type for report: %s" % self.data_type.name)
+
+        self.log("  - report: %s %s" % (len(self.report), len(self.plots)))
+
+    def log(self, msg):
+        """Log a message"""
+        if self.logfile is not None:
+            self.logfile.write(msg + "\n")
+        logger.notice(msg)
+
+
+def generate_event_count_info(workspace: MantidWorkspace) -> str:
+    """Generate an HTML table containing run information (event count and proton charge)
+
+    Parameters
+    ----------
+    workspace : mantid.api.Workspace
+        Event workspace
+
+    Returns
+    -------
+    str
+
+    Notes
+    -----
+    This is useful for live reduction. For a finished run, WebMon fetches this from ONCat.
+    """
+    # self.log("  - generating cross-section report")
+    meta = "<p>\n<table style='width:80%'>"
+    meta += "<tr><td># events:</td><td>%s</td></tr>" % workspace.getNumberEvents()
+
+    p_charge = SampleLogValues(workspace)["gd_prtn_chrg"]
+    meta += "<tr><td>p-charge [uAh]:</td><td>%6.4g</td></tr>" % p_charge
+    meta += "</table>\n<p>\n"
+    return meta
+
+
+def generate_web_report(workspace, template_data, meta_data) -> str:
+    r"""Generate HTML report from a reduced workspace and template data
+
+    Returns
+    -------
+    str
+        Reduction configuration in the form of an HTML table
+    """
+    # self.log("  - generating report")
+
+    sample_logs = SampleLogValues(workspace)
+    direct_beam = template_data.norm_file
+    two_backgrounds = template_data.two_backgrounds
+
+    meta = "<table style='width:80%'>"
+    meta += "<tr><td>Run:</td><td><b>%s</b> </td></td><td><b>Direct beam: %s</b></td></tr>" % (
+        int(sample_logs["run_number"]),
+        direct_beam,
+    )
+    meta += "<tr><td>Q-binning:</td><td>%s</td><td>-</td></tr>" % meta_data["q_summing"]
+    meta += "<tr><td>Specular peak:</td><td>%g</td><td>-</td></tr>" % (
+        meta_data["specular_pixel"],
+    )
+    meta += "<tr><td>Peak range:</td><td>%s - %s</td></td><td>%s - %s</td></tr>" % (
+        template_data.data_peak_range[0],
+        template_data.data_peak_range[1],
+        template_data.norm_peak_range[0],
+        template_data.norm_peak_range[1],
+    )
+    meta += "<tr><td>Two backgrounds:</td><td>%s</td><td>-</td><tr>" % two_backgrounds
+    meta += "<tr><td>Background:</td><td>%s - %s</td><td>%s - %s</td></tr>" % (
+        template_data.background_roi[0],
+        template_data.background_roi[1],
+        template_data.norm_background_roi[0],
+        template_data.norm_background_roi[1],
+    )
+    meta += "<tr><td>Background2:</td><td>%s - %s</td><td>-</td></tr>" % (
+        template_data.background_roi[2],
+        template_data.background_roi[3],
+    )
+    meta += "<tr><td>Low-res range:</td><td>%s - %s</td><td>%s - %s</td></tr>" % (
+        template_data.data_x_range[0],
+        template_data.data_x_range[1],
+        template_data.norm_x_range[0],
+        template_data.norm_x_range[1],
+    )
+    meta += "<tr><td>Sequence:</td><td>%s: %s/%s</td></tr>" % (
+        sample_logs["sequence_id"],
+        sample_logs["sequence_number"],
+        sample_logs["sequence_total"],
+    )
+    meta += "<tr><td>Report time:</td><td>%s</td></tr>" % time.ctime()
+    meta += "</table>\n"
+
+    meta += "<table style='width:100%'>"
+    meta += "<tr><th>Theta (actual)</th><th>Wavelength</th><th>Q</th></tr>"  # noqa E501
+    meta += "<tr><td>%6.4g</td><td>%6.4g - %6.4g</td><td>%6.4g - %6.4g</td></tr>\n" % (
+        meta_data["theta"],
+        meta_data["wl_min"],
+        meta_data["wl_max"],
+        meta_data["q_min"],
+        meta_data["q_max"],
+    )
+    meta += "</table>\n"
+    return meta
+
+
+def generate_plots(workspace: MantidWorkspace, template_data: ReductionParameters):
+    """
+    Generate diagnostics plots
+    """
+    # self.log("  - generating plots [%s]" % self.number_events)
+    # if self.number_events < 10:
+    #     logger.notice("No events for workspace %s" % str(workspace))
+    #     return []
+    n_x = int(workspace.getInstrument().getNumberParameter("number-of-x-pixels")[0])
+    n_y = int(workspace.getInstrument().getNumberParameter("number-of-y-pixels")[0])
+
+    scatt_peak = template_data.data_peak_range
+    scatt_low_res = template_data.data_x_range
+
+    # X-Y plot
+    xy_plot = None
+    try:
+        integrated = Integration(workspace)
+        signal = np.log10(integrated.extractY())
+        z = np.reshape(signal, (n_x, n_y))
+        xy_plot = _plot2d(
+            z=z.T,
+            x=list(range(n_x)),
+            y=list(range(n_y)),
+            x_range=scatt_low_res,
+            y_range=scatt_peak,
+            y_bck_range=template_data.background_roi,
+        )
+    except:  # noqa E722
+        # self.log("  - Could not generate XY plot")
+        xy_plot = _plotText("Could not generate XY plot")
+
+    # self.log("  - generating X-TOF plot")
+    # Y-TOF plot
+    y_tof_plot = None
+    try:
+        tof_min = workspace.getTofMin()
+        tof_max = workspace.getTofMax()
+        workspace = Rebin(workspace, params="%s, 50, %s" % (tof_min, tof_max))
+        # algorithm RefRoi sums up the intensities in a region of interest on a 2D detector
+        # returns a MatrixWorkspace
+        direct_summed = RefRoi(
+            InputWorkspace=workspace,
+            NXPixel=n_x,
+            NYPixel=n_y,
+            ConvertToQ=False,
+            OutputWorkspace="direct_summed",
+        )
+        signal = np.transpose(np.log10(direct_summed.extractY()))
+        tof_axis = direct_summed.extractX()[0] / 1000.0
+        tof_axis = (tof_axis[:-1] + tof_axis[1:]) / 2.0  # average TOF values
+
+        y_tof_plot = _plot2d(
+            z=signal,
+            y=tof_axis,
+            x=list(range(signal.shape[1])),
+            x_range=scatt_peak,
+            x_bck_range=template_data.background_roi,
+            y_range=None,
+            x_label="Y pixel",
+            y_label="TOF (ms)",
+            swap_axes=False,
+        )
+    except:  # noqa E722
+        # self.log("  - Could not generate X-TOF plot")
+        y_tof_plot = _plotText("Could not generate X-TOF plot")
+
+    # self.log("  - generating Y count distribution")
+    # Count per Y pixel
+    peak_pixels = None
+    try:
+        direct_summed = RefRoi(
+            InputWorkspace=workspace,
+            IntegrateY=False,
+            NXPixel=n_x,
+            NYPixel=n_y,
+            ConvertToQ=False,
+            OutputWorkspace="direct_summed",
+        )
+        integrated = Integration(direct_summed)
+        integrated = Transpose(integrated)
+        signal_y = integrated.readY(0)
+        signal_x = np.arange(len(signal_y))
+        peak_pixels = _plot1d(
+            signal_x,
+            signal_y,
+            x_range=scatt_peak,
+            bck_range=template_data.background_roi,  # TODO: handle two backgrounds
+            x_label="Y pixel",
+            y_label="Counts",
+        )
+    except:  # noqa E722
+        # self.log("  - Could not generate Y count distribution")
+        peak_pixels = _plotText(
+            "Could not generate Y count distribution"
+        )
+
+    # self.log("  - generating X count distribution")
+    # Count per X pixel
+    low_res_profile = None
+    try:
+        direct_summed = RefRoi(
+            InputWorkspace=workspace,
+            NXPixel=n_x,
+            NYPixel=n_y,
+            ConvertToQ=False,
+            OutputWorkspace="direct_summed",
+        )
+        integrated = Integration(direct_summed)
+        integrated = Transpose(integrated)
+        signal_y = integrated.readY(0)
+        signal_x = list(range(len(signal_y)))
+        low_res_profile = _plot1d(
+            signal_x,
+            signal_y,
+            x_range=scatt_low_res,
+            x_label="X pixel",
+            y_label="Counts",
+        )
+    except:  # noqa E722
+        # self.log("  - Could not generate X count distribution")
+        low_res_profile = _plotText("Could not generate X count distribution")
+
+    # TOF distribution
+    tof_dist = None
+    try:
+        workspace = SumSpectra(workspace)
+        signal_x = workspace.readX(0) / 1000.0
+        signal_y = workspace.readY(0)
+        tof_dist = _plot1d(
+            signal_x,
+            signal_y,
+            y_log=False,
+            x_range=None,
+            x_label="TOF (ms)",
+            y_label="Counts",
+        )
+    except:  # noqa E722
+        # self.log("  - Could not generate TOF distribution")
+        tof_dist = _plotText(
+            "Could not generate TOF distribution"
+        )
+
+    return [xy_plot, y_tof_plot, peak_pixels, low_res_profile, tof_dist]
+
+
+def _plot2d(
+    x,
+    y,
+    z,
+    x_range=None,
+    y_range=None,
+    x_label="X pixel",
+    y_label="Y pixel",
+    title="",
+    x_bck_range=None,
+    y_bck_range=None,
+    swap_axes=False,
+):
+    """
+    Generate a 2D plot
+    :param array x: x-axis values
+    :param array y: y-axis values
+    :param array z: z-axis counts
+    :param str x_label: x-axis label
+    :param str y_label: y-axis label
+    :param str title: plot title
+    :param array x_bck_range: array of length 2 to specify a background region in x
+    :param array y_bck_range: array of length 2 to specify a background region in y
+    """
+    colorscale = [
+        [0, "rgb(0,0,131)"],
+        [0.125, "rgb(0,60,170)"],
+        [0.375, "rgb(5,255,255)"],
+        [0.625, "rgb(255,255,0)"],
+        [0.875, "rgb(250,0,0)"],
+        [1, "rgb(128,0,0)"],
+    ]
+
+    if swap_axes:
+        x, y = y, x
+        z = z.T
+        x_range, y_range = y_range, x_range
+        x_bck_range, y_bck_range = y_bck_range, x_bck_range
+        x_label, y_label = y_label, x_label
+
+    # Eliminate items in array Z that are not finite and below a certain threshold
+    x_grid, y_grid = np.meshgrid(x, y)
+    x_flat, y_flat, z_flat = x_grid.flatten(), y_grid.flatten(), z.flatten()
+    threshold = 0.01 * np.max(z_flat)
+    mask = np.isfinite(z_flat) & (z_flat > threshold)  # Keep only significant values (exclude NaN, -inf, inf)
+    x_sparse, y_sparse, z_sparse = x_flat[mask], y_flat[mask], z_flat[mask]
+
+    # Round the remaining values to a certain number of decimal places, for instance 0.003455245 to 0.0034.
+    # This will later save disk space when writing the figure to file
+    def leading_decimal_places(x: float):
+        """Calculate the number of leading decimal places for a number between 0 and 1."""
+        if x <= 0 or x >= 1:
+            raise ValueError("x must be between 0 and 1")
+        return abs(math.floor(math.log10(x)))
+
+    z_sparse = np.round(z_sparse, 1 + leading_decimal_places(threshold))
+
+    heatmap = go.Heatmap(
+        x=x_sparse,
+        y=y_sparse,
+        z=z_sparse,
+        autocolorscale=False,
+        type="heatmap",
+        showscale=False,
+        hoverinfo="x+y+z",
+        colorscale=colorscale,
+    )
+
+    x_range_color = "rgba(152, 0, 0, .8)"
+    y_range_color = "rgba(0, 128, 0, 1)"
+    if swap_axes:
+        x_range_color = "rgba(0, 128, 0, 1)"
+        y_range_color = "rgba(152, 0, 0, .8)"
+
+    # Set the color scale limits
+    data = [heatmap]
+    if x_range is not None:
+        x_left = go.Scatter(
+            name="",
+            x=[x_range[0], x_range[0]],
+            y=[min(y), max(y)],
+            marker=dict(
+                color=x_range_color,
+            ),
+        )
+        x_right = go.Scatter(
+            name="",
+            x=[x_range[1], x_range[1]],
+            y=[min(y), max(y)],
+            marker=dict(
+                color=x_range_color,
+            ),
+        )
+        data.append(x_left)
+        data.append(x_right)
+
+    if x_bck_range is not None:
+        x_left = go.Scatter(
+            name="",
+            x=[x_bck_range[0], x_bck_range[0]],
+            y=[min(y), max(y)],
+            marker=dict(
+                color="rgba(152, 152, 152, .8)",
+            ),
+        )
+        x_right = go.Scatter(
+            name="",
+            x=[x_bck_range[1], x_bck_range[1]],
+            y=[min(y), max(y)],
+            marker=dict(
+                color="rgba(152, 152, 152, .8)",
+            ),
+        )
+        data.append(x_left)
+        data.append(x_right)
+
+    if y_range is not None:
+        y_left = go.Scatter(
+            name="",
+            y=[y_range[0], y_range[0]],
+            x=[min(x), max(x)],
+            marker=dict(
+                color=y_range_color,
+            ),
+        )
+        y_right = go.Scatter(
+            name="",
+            y=[y_range[1], y_range[1]],
+            x=[min(x), max(x)],
+            marker=dict(
+                color=y_range_color,
+            ),
+        )
+        data.append(y_left)
+        data.append(y_right)
+
+    if y_bck_range is not None:
+        y_left = go.Scatter(
+            name="",
+            y=[y_bck_range[0], y_bck_range[0]],
+            x=[min(x), max(x)],
+            marker=dict(
+                color="rgba(152, 152, 152, .8)",
+            ),
+        )
+        y_right = go.Scatter(
+            name="",
+            y=[y_bck_range[1], y_bck_range[1]],
+            x=[min(x), max(x)],
+            marker=dict(
+                color="rgba(152, 152, 152, .8)",
+            ),
+        )
+        data.append(y_left)
+        data.append(y_right)
+
+    x_layout = dict(
+        title=x_label,
+        zeroline=False,
+        exponentformat="power",
+        showexponent="all",
+        showgrid=True,
+        showline=True,
+        mirror="all",
+        ticks="inside",
+    )
+    y_layout = dict(
+        title=y_label,
+        zeroline=False,
+        exponentformat="power",
+        showexponent="all",
+        showgrid=True,
+        showline=True,
+        mirror="all",
+        ticks="inside",
+    )
+    layout = go.Layout(
+        title=title,
+        showlegend=False,
+        autosize=True,
+        width=300,
+        height=300,
+        margin=dict(t=40, b=40, l=40, r=20),
+        hovermode="closest",
+        bargap=0,
+        xaxis=x_layout,
+        yaxis=y_layout,
+    )
+    fig = go.Figure(data=data, layout=layout)
+    return pyo.plot(fig, output_type="div", include_plotlyjs=False, show_link=False)
+
+
+def _plot1d(
+    x, y, x_range=None, y_range=None, x_label="", y_label="Counts", title="", bck_range=None, x_log=False, y_log=True
+) -> str:
+    r"""Generate a simple 1D plot as an HTML snippet containing a Plotly graph embedded within a web page
+
+    Parameters
+    ----------
+    x: np.ndarray
+        x-axis values
+    y: np.ndarray
+    x_label: str
+        x-axis label
+    y_label: str
+        y-axis label
+    title: str
+        plot title
+    bck_range: np.ndarray, list
+        array of length 2 to specify a background region in x
+    x_log: bool
+        if true, the x-axis will be a log scale
+    y_log: bool
+        if true, the y-axis will be a log scale
+
+    Returns
+    -------
+    str
+    """
+    data = [go.Scatter(name="", x=x, y=y)]
+
+    if x_range is not None:
+        min_y = min([v for v in y if v > 0])
+        x_left = go.Scatter(
+            name="",
+            x=[x_range[0], x_range[0]],
+            y=[min_y, max(y)],
+            marker=dict(
+                color="rgba(152, 0, 0, .8)",
+            ),
+        )
+        x_right = go.Scatter(
+            name="",
+            x=[x_range[1], x_range[1]],
+            y=[min_y, max(y)],
+            marker=dict(
+                color="rgba(152, 0, 0, .8)",
+            ),
+        )
+        data.append(x_left)
+        data.append(x_right)
+
+    if y_range is not None:
+        min_x = min([v for v in x if v > 0])
+        y_left = go.Scatter(
+            name="",
+            y=[y_range[0], y_range[0]],
+            x=[min_x, max(x)],
+            marker=dict(
+                color="rgba(0, 128, 0, 1)",
+            ),
+        )
+        y_right = go.Scatter(
+            name="",
+            y=[y_range[1], y_range[1]],
+            x=[min_x, max(x)],
+            marker=dict(
+                color="rgba(0, 128, 0, 1)",
+            ),
+        )
+        data.append(y_left)
+        data.append(y_right)
+
+    if bck_range is not None:
+        min_y = min([v for v in y if v > 0])
+        x_left = go.Scatter(
+            name="",
+            x=[bck_range[0], bck_range[0]],
+            y=[min_y, max(y)],
+            marker=dict(
+                color="rgba(152, 152, 152, .8)",
+            ),
+        )
+        x_right = go.Scatter(
+            name="",
+            x=[bck_range[1], bck_range[1]],
+            y=[min_y, max(y)],
+            marker=dict(
+                color="rgba(152, 152, 152, .8)",
+            ),
+        )
+        data.append(x_left)
+        data.append(x_right)
+
+    x_layout = dict(
+        title=x_label,
+        zeroline=False,
+        exponentformat="power",
+        showexponent="all",
+        showgrid=True,
+        showline=True,
+        mirror="all",
+        ticks="inside",
+    )
+    if x_log:
+        x_layout["type"] = "log"
+
+    y_layout = dict(
+        title=y_label,
+        zeroline=False,
+        exponentformat="power",
+        showexponent="all",
+        showgrid=True,
+        showline=True,
+        mirror="all",
+        ticks="inside",
+    )
+    if y_log:
+        y_layout["type"] = "log"
+
+    layout = go.Layout(
+        title=title,
+        showlegend=False,
+        autosize=True,
+        width=300,
+        height=300,
+        margin=dict(t=40, b=40, l=40, r=20),
+        hovermode="closest",
+        bargap=0,
+        xaxis=x_layout,
+        yaxis=y_layout,
+    )
+
+    fig = go.Figure(data=data, layout=layout)
+    return pyo.plot(fig, output_type="div", include_plotlyjs=False, show_link=False)
+
+
+def plot1d(
+    run_number,  # noqa ARG001
+    data_list,
+    data_names=None,
+    x_title="",
+    y_title="",
+    x_log=False,
+    y_log=False,
+    instrument="",  # noqa ARG001
+    show_dx=True,
+    title="",
+    publish=False,  # noqa ARG001
+):
+    r"""
+    Produce a 1D plot in the style of the autoreduction output.
+    The function signature is meant to match the autoreduction publisher.
+    @param data_list: list of traces [ [x1, y1], [x2, y2], ...]
+    @param data_names: name for each trace, for the legend
+
+    Arguments run_number, instrument, and publish are unused because this function is not meant to upload
+    anything to the livedata server.
+    """
+    # Create traces
+    if not isinstance(data_list, list):
+        raise RuntimeError("plot1d: data_list parameter is expected to be a list")
+
+    # Catch the case where the list is in the format [x y]
+    data = []
+    show_legend = False
+    if len(data_list) == 2 and not isinstance(data_list[0], list):
+        label = ""
+        if isinstance(data_names, list) and len(data_names) == 1:
+            label = data_names[0]
+            show_legend = True
+        data = [go.Scatter(name=label, x=data_list[0], y=data_list[1])]
+    else:
+        for i in range(len(data_list)):
+            label = ""
+            if isinstance(data_names, list) and len(data_names) == len(data_list):
+                label = data_names[i]
+                show_legend = True
+            err_x = {}
+            err_y = {}
+            if len(data_list[i]) >= 3:
+                err_y = dict(type="data", array=data_list[i][2], visible=True)
+            if len(data_list[i]) >= 4:
+                err_x = dict(type="data", array=data_list[i][3], visible=True)
+                if show_dx is False:
+                    err_x["thickness"] = 0
+            data.append(go.Scatter(name=label, x=data_list[i][0], y=data_list[i][1], error_x=err_x, error_y=err_y))
+
+    x_layout = dict(
+        title=x_title,
+        zeroline=False,
+        exponentformat="power",
+        showexponent="all",
+        showgrid=True,
+        showline=True,
+        mirror="all",
+        ticks="inside",
+    )
+    if x_log:
+        x_layout["type"] = "log"
+    y_layout = dict(
+        title=y_title,
+        zeroline=False,
+        exponentformat="power",
+        showexponent="all",
+        showgrid=True,
+        showline=True,
+        mirror="all",
+        ticks="inside",
+    )
+    if y_log:
+        y_layout["type"] = "log"
+
+    layout = go.Layout(
+        showlegend=show_legend,
+        autosize=True,
+        width=600,
+        height=400,
+        margin=dict(t=40, b=40, l=80, r=40),
+        hovermode="closest",
+        bargap=0,
+        xaxis=x_layout,
+        yaxis=y_layout,
+        title=title,
+    )
+
+    fig = go.Figure(data=data, layout=layout)
+    plot_div = pyo.plot(fig, output_type="div", include_plotlyjs=False, show_link=False)
+    return plot_div
+
+
+def _plotText(text, title=""):
+    r"""
+    Displays an informative message as a plot
+
+    :param: text: str, the text to be displayed
+    :param: title: str, the title of the plot
+    :return: py.plot, the plot
+    """
+
+    layout = go.Layout(
+        annotations=[
+            dict(
+                text=text,
+                font=dict(size=13, color="red"),
+                xref="paper",  # `paper` sets relative coordinates
+                yref="paper",
+                align="center",
+                x=0.5,
+                y=0.5,
+                showarrow=False,
+            )
+        ],
+        autosize=True,
+        title=title,
+        xaxis=dict(visible=False),
+        yaxis=dict(visible=False),
+        showlegend=False,
+    )
+
+    fig = go.Figure(layout=layout)
+    plot = pyo.plot(fig, output_type="div", include_plotlyjs=False, show_link=False)
+
+    return plot

--- a/src/lr_reduction/web_report.py
+++ b/src/lr_reduction/web_report.py
@@ -303,7 +303,7 @@ def generate_report_section_reduction_parameters(workspace: MantidWorkspace, tem
         template_data.norm_peak_range[0],
         template_data.norm_peak_range[1],
     )
-    meta += "<tr><td>Two backgrounds:</td><td>%s</td><td>-</td><tr>" % two_backgrounds
+    meta += "<tr><td>Two backgrounds:</td><td>%s</td><td>-</td></tr>" % two_backgrounds
     meta += "<tr><td>Background:</td><td>%s - %s</td><td>%s - %s</td></tr>" % (
         template_data.background_roi[0],
         template_data.background_roi[1],
@@ -562,16 +562,16 @@ def _plot2d(
     x: np.ndarray,
     y: np.ndarray,
     z: np.ndarray | list,
-    x_range: list=None,
-    y_range: list=None,
-    x_label: str="X pixel",
-    y_label: str="Y pixel",
-    title: str="",
-    x_bck_range: list=None,
-    y_bck_range: list=None,
-    swap_axes: bool=False,
-    x_zoom_range: list=None,
-    y_zoom_range: list=None,
+    x_range: list = None,
+    y_range: list = None,
+    x_label: str = "X pixel",
+    y_label: str = "Y pixel",
+    title: str = "",
+    x_bck_range: list = None,
+    y_bck_range: list = None,
+    swap_axes: bool = False,
+    x_zoom_range: list = None,
+    y_zoom_range: list = None,
 ):
     """
     Generate a simple 2D plot as an HTML snippet containing a Plotly graph embedded within a web page

--- a/src/lr_reduction/workflow.py
+++ b/src/lr_reduction/workflow.py
@@ -19,7 +19,7 @@ def reduce(
     output_dir: str,
     average_overlap: bool = False,
     theta_offset: float | None = 0,
-    q_summing: bool = None,
+    q_summing: bool | None = None,
     bck_in_q: bool = False,
     is_live: bool = False,
     return_report: bool = False,
@@ -55,8 +55,9 @@ def reduce(
 
     Returns
     -------
-    int
-        The sequence identifier for the run sequence
+    int or tuple
+        The sequence identifier for the run sequence, or a tuple of
+        (sequence_id, report_html) if return_report is True.
     """
     # Get the sequence number
     sequence_number = 1
@@ -105,6 +106,12 @@ def reduce(
         write_template(seq_list, run_list, template_file, output_dir)
     else:
         logger.notice("Template data was passed instead of a file path: template data not saved")
+
+    if not run_list:
+        logger.warning("No partial results found to assemble")
+        if return_report:
+            return None, report
+        return None
 
     if return_report:
         return run_list[0], report

--- a/tests/integration/lr_autoreduce/test_reduce_ref_l.py
+++ b/tests/integration/lr_autoreduce/test_reduce_ref_l.py
@@ -1,0 +1,40 @@
+import os
+
+import pytest
+
+from lr_autoreduce.reduce_REF_L import autoreduce
+from lr_reduction import template
+from lr_reduction.utils import amend_config
+
+
+@pytest.mark.datarepo
+def test_autoreduce_reflected(nexus_dir, template_dir, tmp_path):
+    """Test REF_L autoreduction for reflected data"""
+    events_file = "REF_L_201282.nxs.h5"
+    output_dir = tmp_path / "output"
+    template_file = os.path.join(template_dir, "template_201282.xml")
+    template_data = template.read_template(template_file, 1)
+    template_data.scaling_factor_flag = False
+
+    with amend_config(data_dir=nexus_dir):
+        autoreduce(events_file, output_dir, template_data, publish=False)
+
+    # Check that output files are created
+    assert (output_dir / "REF_L_201282.html").exists()
+    assert (output_dir / "REFL_201282_1_201282_partial.txt").exists()
+    assert (output_dir / "REFL_201282_combined_data_auto.txt").exists()
+
+
+@pytest.mark.datarepo
+def test_autoreduce_direct(nexus_dir, template_dir, tmp_path):
+    """Test REF_L autoreduction for direct beam data"""
+    events_file = "REF_L_201043.nxs.h5"
+    output_dir = tmp_path / "output"
+    template_file = os.path.join(template_dir, "template_201282.xml")
+    template_data = template.read_template(template_file, 1)
+
+    with amend_config(data_dir=nexus_dir):
+        autoreduce(events_file, output_dir, template_data, publish=False)
+
+    # Check that the HTML report is created
+    assert (output_dir / "REF_L_201043.html").exists()

--- a/tests/unit/lr_reduction/test_data_info.py
+++ b/tests/unit/lr_reduction/test_data_info.py
@@ -76,19 +76,7 @@ def test_from_workspace_direct_beam_beam_centered(mock_sample_logs_class):
     assert result == DataType.DIRECT_BEAM
 
 
-@patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_missing_logs(mock_sample_logs_class):
+def test_from_workspace_missing_logs():
     """Test that missing logs default to reflected beam"""
-    mock_sample_logs_class.side_effect = KeyError("Missing log")
-
-    result = DataType.from_workspace(Mock())
-    assert result == DataType.REFLECTED_BEAM
-
-
-@patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_exception_handling(mock_sample_logs_class):
-    """Test that exceptions default to reflected beam"""
-    mock_sample_logs_class.side_effect = Exception("Unexpected error")
-
     result = DataType.from_workspace(Mock())
     assert result == DataType.REFLECTED_BEAM

--- a/tests/unit/lr_reduction/test_data_info.py
+++ b/tests/unit/lr_reduction/test_data_info.py
@@ -8,8 +8,8 @@ def test_from_workspace_direct_beam_earth_centered_coordinates(mock_sample_logs_
     """Test direct beam detection with earth-centered coordinates"""
     mock_logs = {
         "BL4B:CS:Mode:Coordinates": 0,
-        "thi": 0.005,
-        "tthd": 0.005,
+        "thi": 0.800,
+        "tthd": 0.805,
     }
     mock_sample_logs_class.return_value = mock_logs
 
@@ -23,8 +23,8 @@ def test_from_workspace_direct_beam_free_liquid_mode(mock_sample_logs_class):
     mock_logs = {
         "BL4B:CS:Mode:Coordinates": 1,
         "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
-        "thi": 0.0,
-        "tthd": 0.0,
+        "thi": 0.210,
+        "tthd": 0.212,
     }
     mock_sample_logs_class.return_value = mock_logs
 
@@ -67,8 +67,8 @@ def test_from_workspace_direct_beam_beam_centered(mock_sample_logs_class):
     mock_logs = {
         "BL4B:CS:Mode:Coordinates": 1,
         "BL4B:CS:ExpPl:OperatingMode": "Other",
-        "ths": 0.0,
-        "tthd": 0.0,
+        "ths": 0.0006,
+        "tthd": 0.0008,
     }
     mock_sample_logs_class.return_value = mock_logs
 

--- a/tests/unit/lr_reduction/test_data_info.py
+++ b/tests/unit/lr_reduction/test_data_info.py
@@ -1,0 +1,94 @@
+from unittest.mock import Mock, patch
+
+from lr_reduction.data_info import DataType
+
+
+@patch("lr_reduction.data_info.SampleLogValues")
+def test_from_workspace_direct_beam_earth_centered_coordinates(mock_sample_logs_class):
+    """Test direct beam detection with earth-centered coordinates"""
+    mock_logs = {
+        "BL4B:CS:Mode:Coordinates": 0,
+        "thi": 0.005,
+        "tthd": 0.005,
+    }
+    mock_sample_logs_class.return_value = mock_logs
+
+    result = DataType.from_workspace(Mock())
+    assert result == DataType.DIRECT_BEAM
+
+
+@patch("lr_reduction.data_info.SampleLogValues")
+def test_from_workspace_direct_beam_free_liquid_mode(mock_sample_logs_class):
+    """Test direct beam detection with free liquid mode"""
+    mock_logs = {
+        "BL4B:CS:Mode:Coordinates": 1,
+        "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
+        "thi": 0.0,
+        "tthd": 0.0,
+    }
+    mock_sample_logs_class.return_value = mock_logs
+
+    result = DataType.from_workspace(Mock())
+    assert result == DataType.DIRECT_BEAM
+
+
+@patch("lr_reduction.data_info.SampleLogValues")
+def test_from_workspace_reflected_beam_earth_centered(mock_sample_logs_class):
+    """Test reflected beam detection with earth-centered coordinates"""
+    mock_logs = {
+        "BL4B:CS:Mode:Coordinates": 0,
+        "thi": 0.5,
+        "tthd": 1.0,
+    }
+    mock_sample_logs_class.return_value = mock_logs
+
+    result = DataType.from_workspace(Mock())
+    assert result == DataType.REFLECTED_BEAM
+
+
+@patch("lr_reduction.data_info.SampleLogValues")
+def test_from_workspace_reflected_beam_beam_centered(mock_sample_logs_class):
+    """Test reflected beam detection with beam-centered coordinates"""
+    mock_logs = {
+        "BL4B:CS:Mode:Coordinates": 1,
+        "BL4B:CS:ExpPl:OperatingMode": "Other",
+        "ths": 0.5,
+        "tthd": 1.0,
+    }
+    mock_sample_logs_class.return_value = mock_logs
+
+    result = DataType.from_workspace(Mock())
+    assert result == DataType.REFLECTED_BEAM
+
+
+@patch("lr_reduction.data_info.SampleLogValues")
+def test_from_workspace_direct_beam_beam_centered(mock_sample_logs_class):
+    """Test direct beam detection with beam-centered coordinates"""
+    mock_logs = {
+        "BL4B:CS:Mode:Coordinates": 1,
+        "BL4B:CS:ExpPl:OperatingMode": "Other",
+        "ths": 0.0,
+        "tthd": 0.0,
+    }
+    mock_sample_logs_class.return_value = mock_logs
+
+    result = DataType.from_workspace(Mock())
+    assert result == DataType.DIRECT_BEAM
+
+
+@patch("lr_reduction.data_info.SampleLogValues")
+def test_from_workspace_missing_logs(mock_sample_logs_class):
+    """Test that missing logs default to reflected beam"""
+    mock_sample_logs_class.side_effect = KeyError("Missing log")
+
+    result = DataType.from_workspace(Mock())
+    assert result == DataType.REFLECTED_BEAM
+
+
+@patch("lr_reduction.data_info.SampleLogValues")
+def test_from_workspace_exception_handling(mock_sample_logs_class):
+    """Test that exceptions default to reflected beam"""
+    mock_sample_logs_class.side_effect = Exception("Unexpected error")
+
+    result = DataType.from_workspace(Mock())
+    assert result == DataType.REFLECTED_BEAM

--- a/tests/unit/lr_reduction/test_data_info.py
+++ b/tests/unit/lr_reduction/test_data_info.py
@@ -76,7 +76,10 @@ def test_from_workspace_direct_beam_beam_centered(mock_sample_logs_class):
     assert result == DataType.DIRECT_BEAM
 
 
-def test_from_workspace_missing_logs():
+@patch("lr_reduction.data_info.SampleLogValues")
+def test_from_workspace_missing_logs(mock_sample_logs_class):
     """Test that missing logs default to reflected beam"""
+    mock_sample_logs_class.return_value = {}
+
     result = DataType.from_workspace(Mock())
     assert result == DataType.REFLECTED_BEAM

--- a/tests/unit/lr_reduction/test_output.py
+++ b/tests/unit/lr_reduction/test_output.py
@@ -1,0 +1,187 @@
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lr_reduction.output import RunCollection, read_file
+
+
+class TestRunCollection:
+    """Test cases for RunCollection class"""
+
+    def test_add_with_dq(self):
+        """Test adding data with explicit dq values"""
+        rc = RunCollection()
+        q = np.array([0.1, 0.2, 0.3])
+        r = np.array([1.0, 0.5, 0.2])
+        dr = np.array([0.1, 0.05, 0.02])
+        dq = np.array([0.01, 0.02, 0.03])
+        meta = {"experiment": "test", "run_number": 1}
+
+        rc.add(q, r, dr, meta, dq=dq)
+
+        assert len(rc.collection) == 1
+        assert np.array_equal(rc.collection[0]["q"], q)
+        assert np.array_equal(rc.collection[0]["dq"], dq)
+
+    def test_add_without_dq(self):
+        """Test adding data without dq, should compute from metadata"""
+        rc = RunCollection()
+        q = np.array([0.1, 0.2, 0.3])
+        r = np.array([1.0, 0.5, 0.2])
+        dr = np.array([0.1, 0.05, 0.02])
+        meta = {"experiment": "test", "run_number": 1, "dq_over_q": 0.05}
+
+        rc.add(q, r, dr, meta)
+
+        expected_dq = 0.05 * q
+        assert np.allclose(rc.collection[0]["dq"], expected_dq)
+
+    def test_merge_single_run(self):
+        """Test merging with a single run"""
+        rc = RunCollection()
+        q = np.array([0.1, 0.2, 0.3])
+        r = np.array([1.0, 0.5, 0.2])
+        dr = np.array([0.1, 0.05, 0.02])
+        dq = np.array([0.01, 0.02, 0.03])
+        meta = {"experiment": "test", "run_number": 1}
+
+        rc.add(q, r, dr, meta, dq=dq)
+        rc.merge()
+
+        assert np.array_equal(rc.qz_all, q)
+        assert np.array_equal(rc.refl_all, r)
+        assert np.array_equal(rc.d_refl_all, dr)
+        assert np.array_equal(rc.d_qz_all, dq)
+
+    def test_merge_multiple_runs_sorted(self):
+        """Test merging multiple runs with sorting"""
+        rc = RunCollection()
+        q1 = np.array([0.3, 0.1])
+        r1 = np.array([0.2, 1.0])
+        dr1 = np.array([0.02, 0.1])
+        dq1 = np.array([0.03, 0.01])
+        meta1 = {"experiment": "test", "run_number": 1}
+
+        q2 = np.array([0.2])
+        r2 = np.array([0.5])
+        dr2 = np.array([0.05])
+        dq2 = np.array([0.02])
+        meta2 = {"experiment": "test", "run_number": 2}
+
+        rc.add(q1, r1, dr1, meta1, dq=dq1)
+        rc.add(q2, r2, dr2, meta2, dq=dq2)
+        rc.merge()
+
+        # Check sorting by q
+        expected_q = np.array([0.1, 0.2, 0.3])
+        assert np.array_equal(rc.qz_all, expected_q)
+        assert np.array_equal(rc.refl_all, np.array([1.0, 0.5, 0.2]))
+
+    def test_merge_with_average_overlap(self):
+        """Test merging with averaging overlapping points"""
+        rc = RunCollection(average_overlap=True)
+
+        # Add two runs with overlapping q values
+        q1 = np.array([0.1, 0.2])
+        r1 = np.array([1.0, 2.0])
+        dr1 = np.array([0.1, 0.2])
+        dq1 = np.array([0.01, 0.01])
+        meta1 = {"experiment": "test", "run_number": 1}
+
+        q2 = np.array([0.2])
+        r2 = np.array([0.5])
+        dr2 = np.array([0.05])
+        dq2 = np.array([0.02])
+        meta2 = {"experiment": "test", "run_number": 2}
+
+        rc.add(q1, r1, dr1, meta1, dq=dq1)
+        rc.add(q2, r2, dr2, meta2, dq=dq2)
+        rc.merge()
+
+        assert np.array_equal(rc.qz_all, np.array([0.1, 0.2]))
+        assert np.array_equal(rc.refl_all, np.array([1.0, (2.0 + 0.5) / 2]))
+
+    def test_save_ascii(self):
+        """Test saving data to ASCII file"""
+        rc = RunCollection()
+        q = np.array([0.1, 0.2])
+        r = np.array([1.0, 0.5])
+        dr = np.array([0.1, 0.05])
+        dq = np.array([0.01, 0.02])
+        meta = {
+            "experiment": "test_exp",
+            "run_number": 1,
+            "run_title": "Test Run",
+            "start_time": "2021-01-01 10:00:00",
+            "time": "2021-01-01 10:05:00",
+            "theta": 0.01,
+            "norm_run": 0,
+            "wl_min": 1.0,
+            "wl_max": 10.0,
+            "q_min": 0.01,
+            "q_max": 1.0,
+        }
+
+        rc.add(q, r, dr, meta, dq=dq)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "output.txt"
+            rc.save_ascii(str(file_path))
+
+            with open(file_path, "r") as f:
+                content = f.read()
+                assert "# Experiment test_exp Run 1" in content
+                assert "# Run title: Test Run" in content
+                assert "Q [1/Angstrom]" in content
+                assert "0.1" in content
+
+    def test_add_from_file(self):
+        """Test reading and adding data from file"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "input.txt"
+
+            # Create a test file
+            meta = {"test": "data"}
+            with open(file_path, "w") as f:
+                f.write(f"# Meta:{json.dumps(meta)}\n")
+                f.write("0.1  1.0  0.1  0.01\n")
+                f.write("0.2  0.5  0.05  0.02\n")
+
+            rc = RunCollection()
+            rc.add_from_file(str(file_path))
+
+            assert len(rc.collection) == 1
+            assert rc.collection[0]["info"]["test"] == "data"
+
+    def test_read_file_valid(self):
+        """Test reading a valid data file"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "data.txt"
+            meta = {"run": 1, "exp": "test"}
+
+            with open(file_path, "w") as f:
+                f.write(f"# Meta:{json.dumps(meta)}\n")
+                f.write("0.1  1.0  0.1  0.01\n")
+                f.write("0.2  0.5  0.05  0.02\n")
+
+            q, r, dr, dq, read_meta = read_file(str(file_path))
+
+            assert len(q) == 2
+            assert q[0] == pytest.approx(0.1)
+            assert read_meta == meta
+
+    def test_read_file_empty(self):
+        """Test reading an empty or invalid data file"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "empty.txt"
+
+            with open(file_path, "w") as f:
+                f.write("# No data\n")
+
+            q, r, dr, dq, meta = read_file(str(file_path))
+
+            assert len(q) == 0
+            assert meta == {}

--- a/tests/unit/lr_reduction/test_web_report.py
+++ b/tests/unit/lr_reduction/test_web_report.py
@@ -70,7 +70,7 @@ def meta_data(workspace_sc, workspace_db, template_data):
 
 def test_generate_report_section_reduction_parameters(workspace_sc, template_data, meta_data):
     report = generate_report_section_reduction_parameters(workspace_sc, template_data, meta_data)
-    assert len(report) == 820
+    assert len(report) == 787
 
 
 def test_generate_report_plots(workspace_sc, template_data):

--- a/tests/unit/lr_reduction/test_web_report.py
+++ b/tests/unit/lr_reduction/test_web_report.py
@@ -54,12 +54,12 @@ def meta_data(workspace_sc, workspace_db, template_data):
     event_refl = EventReflectivity(workspace_sc,
                                    workspace_db,
                                    peak,
-                                    template_data.background_roi,
-                                    template_data.norm_peak_range,
-                                    template_data.norm_background_roi,
-                                    peak_center,
-                                    template_data.data_x_range,
-                                    template_data.norm_x_range,
+                                   template_data.background_roi,
+                                   template_data.norm_peak_range,
+                                   template_data.norm_background_roi,
+                                   peak_center,
+                                   template_data.data_x_range,
+                                   template_data.norm_x_range,
                                    theta=theta)
 
     meta_data = event_refl.to_dict()
@@ -71,7 +71,7 @@ def meta_data(workspace_sc, workspace_db, template_data):
 
 def test_generate_report_section_reduction_parameters(workspace_sc, template_data, meta_data):
     report = generate_report_section_reduction_parameters(workspace_sc, template_data, meta_data)
-    assert len(report) == 787
+    assert len(report) == 788
 
 
 def test_generate_report_plots_reflected_beam(workspace_sc, template_data):

--- a/tests/unit/lr_reduction/test_web_report.py
+++ b/tests/unit/lr_reduction/test_web_report.py
@@ -1,0 +1,100 @@
+import os
+
+import numpy as np
+import pytest
+from mantid.kernel import amend_config
+from mantid.simpleapi import LoadEventNexus
+
+from lr_reduction import template
+from lr_reduction.event_reduction import EventReflectivity
+from lr_reduction.mantid_utils import SampleLogValues
+from lr_reduction.web_report import (
+    ReportGenerator,
+    generate_event_count_info,
+    generate_plots,
+    generate_web_report,
+    html_wrapper,
+)
+
+
+@pytest.fixture(scope="module")
+def workspace_sc(nexus_dir):
+    """Fixture to create a Report object for testing."""
+    with amend_config(data_dir=nexus_dir):
+        ws = LoadEventNexus("REF_L_201288")
+    return ws
+
+
+@pytest.fixture(scope="module")
+def workspace_db(nexus_dir):
+    """Fixture to create a Report object for testing."""
+    with amend_config(data_dir=nexus_dir):
+        ws_db = LoadEventNexus("REF_L_201051")
+    return ws_db
+
+
+@pytest.fixture(scope="module")
+def template_data(workspace_sc, template_dir):
+    """Fixture to create template data for testing."""
+    sequence_number = workspace_sc.getRun().getProperty("sequence_number").value[0]
+    template_path = os.path.join(template_dir, "template.xml")
+    template_data = template.read_template(template_path, sequence_number)
+    return template_data
+
+
+@pytest.fixture(scope="module")
+def meta_data(workspace_sc, workspace_db, template_data):
+    """Fixture to create a Report object for testing."""
+    peak = template_data.data_peak_range
+    peak_center = (peak[0] + peak[1]) / 2.0
+    sample_logs = SampleLogValues(workspace_sc)
+    theta = sample_logs["ths"] * np.pi / 180.0  # radians
+
+    event_refl = EventReflectivity(workspace_sc,
+                                   workspace_db,
+                                   peak,
+                                    template_data.background_roi,
+                                    template_data.norm_peak_range,
+                                    template_data.norm_background_roi,
+                                    peak_center,
+                                    template_data.data_x_range,
+                                    template_data.norm_x_range,
+                                   theta=theta)
+
+    meta_data = event_refl.to_dict()
+    meta_data["tof_weighted"] = False
+    meta_data["bck_in_q"] = False
+    meta_data["theta_offset"] = template_data.angle_offset
+    return meta_data
+
+
+def test_generate_web_report(workspace_sc, template_data, meta_data):
+    report = generate_web_report(workspace_sc, template_data, meta_data)
+    with open("/home/u5z/output.html", "w") as file:
+        file.write(report)
+    # assert len(report) == 2
+
+
+def test_generate_plots(workspace_sc, template_data):
+    html_plots = generate_plots(workspace_sc, template_data)
+    plot_html = "<table style='width:100%'>\n"
+    plot_html += "<tr>\n"
+    for plot in html_plots:
+        if plot is not None:
+            plot_html += "<td>%s</td>\n" % plot
+    plot_html += "</tr>\n"
+    plot_html += "</table>\n"
+    with open("/home/u5z/plots_output.html", "w") as file:
+        file.write(html_wrapper(plot_html))
+
+
+def test_generate_event_count_info(workspace_sc):
+    info_html = generate_event_count_info(workspace_sc)
+    with open("/home/u5z/info_output.html", "w") as file:
+        file.write(html_wrapper(info_html))
+
+
+def test_generate_report(workspace_sc, template_data, meta_data):
+    generator = ReportGenerator(workspace_sc, template_data, meta_data)
+    report = generator.generate()
+    assert report

--- a/tests/unit/lr_reduction/test_web_report.py
+++ b/tests/unit/lr_reduction/test_web_report.py
@@ -29,7 +29,7 @@ def workspace_sc(nexus_dir):
 def workspace_db(nexus_dir):
     """Fixture to load a Mantid workspace for direct beam data."""
     with amend_config(data_dir=nexus_dir):
-        ws_db = LoadEventNexus("REF_L_201051")
+        ws_db = LoadEventNexus("REF_L_198399")
     return ws_db
 
 
@@ -91,8 +91,15 @@ def test_generate_report_sections(workspace_sc, template_data, meta_data):
     assert report_sections.plots is not None
 
 
+def test_generate_report_section_direct_beam(workspace_db, template_data):
+    report_sections = generate_report_sections(workspace_db, template_data)
+    assert report_sections.run_meta_data is not None
+    assert report_sections.reduction_parameters is not None
+    assert report_sections.plots is not None
+
+
 def test_assemble_report(workspace_sc, template_data, meta_data):
     report_sections = generate_report_sections(workspace_sc, template_data, meta_data)
     report = assemble_report(None, report_sections)
-    assert "<html>" in report
-    assert "</html>" in report
+    assert "<div>" in report
+    assert "</div>" in report

--- a/tests/unit/lr_reduction/test_web_report.py
+++ b/tests/unit/lr_reduction/test_web_report.py
@@ -6,6 +6,7 @@ from mantid.kernel import amend_config
 from mantid.simpleapi import LoadEventNexus
 
 from lr_reduction import template
+from lr_reduction.data_info import DataType
 from lr_reduction.event_reduction import EventReflectivity
 from lr_reduction.mantid_utils import SampleLogValues
 from lr_reduction.web_report import (
@@ -73,8 +74,14 @@ def test_generate_report_section_reduction_parameters(workspace_sc, template_dat
     assert len(report) == 787
 
 
-def test_generate_report_plots(workspace_sc, template_data):
-    html_plots = generate_report_plots(workspace_sc, template_data)
+def test_generate_report_plots_reflected_beam(workspace_sc, template_data):
+    html_plots = generate_report_plots(workspace_sc, template_data, DataType.REFLECTED_BEAM)
+    assert len(html_plots) == 5
+    assert None not in html_plots
+
+
+def test_generate_report_plots_direct_beam(workspace_db, template_data):
+    html_plots = generate_report_plots(workspace_db, template_data, DataType.DIRECT_BEAM)
     assert len(html_plots) == 5
     assert None not in html_plots
 


### PR DESCRIPTION
## Description of work:

Add additional diagnostic plots and metadata to the autoreduction HTML report published to WebMon. Previously, only the reflectivity plot was shown.

The module `web_report` is copied from https://github.com/neutrons/MagnetismReflectometer and then amended e.g. to remove handling of polarization cross-sections and to add metadata relevant to the Liquids Reflectometer.

Check all that apply:
- [x] updated documentation
- [x] Source added/refactored
- [x] Added unit tests
- [x] Added integration tests
- [ ] ~~Verified that tests requiring the /SNS and /HFIR filesystems pass without fail~~

**References:**
- Links to IBM EWM items: [Story 13227: [lr_reduction][WebMon] Add additional diagnostic plots to the output screen on monitor.](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=13227)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

Run the autoreduction script for a run and inspect the saved HTML report.

```
mkdir output/
python src/lr_autoreduce/reduce_REF_L.py /SNS/REF_L/IPTS-35571/nexus/REF_L_223298.nxs.h5 output/ --no_publish
firefox output/REF_L_222983.html
```

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
