### PR TITLE
Test import of lr_autoreduce in CI pipeline

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           python-version: "3.11"
           local-channel: /tmp/local-channel
+          module-name: ${{ env.PKG_NAME }}
           package-name: ${{ env.PKG_NAME }}=${{ env.PKG_VERSION }} # install exact version
           extra-channels: neutrons mantid
           extra-commands: |

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -81,8 +81,6 @@ jobs:
           pixi run conda-build
           mkdir -p /tmp/local-channel/noarch
           cp *.conda /tmp/local-channel/noarch/
-          # extract version from the package file name "lr_reduction-<version>-<build>.conda"
-          echo "PKG_VERSION=$(ls *.conda | cut -d'-' -f2)" >> $GITHUB_ENV
 
       - name: Verify Conda Package
         uses: neutrons/conda-verify@v0.1.2
@@ -90,7 +88,7 @@ jobs:
           python-version: "3.11"
           local-channel: /tmp/local-channel
           module-name: ${{ env.PKG_NAME }}
-          package-name: ${{ env.PKG_NAME }}=${{ env.PKG_VERSION }} # install exact version
+          package-name: ${{ env.PKG_NAME }}
           extra-channels: neutrons mantid
           extra-commands: |
             python -c "import lr_reduction"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -61,6 +61,10 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -el {0}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -71,11 +75,26 @@ jobs:
 
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
-        with:
-          pixi-version: v0.48.2
 
       - name: Build conda package
-        run: pixi run conda-build
+        run: |
+          pixi run conda-build
+          mkdir -p /tmp/local-channel/noarch
+          cp *.conda /tmp/local-channel/noarch/
+          # extract version from the package file name "lr_reduction-<version>-<build>.conda"
+          echo "PKG_VERSION=$(ls *.conda | cut -d'-' -f2)" >> $GITHUB_ENV
+
+      - name: Verify Conda Package
+        uses: neutrons/conda-verify@v0.1.2
+        with:
+          python-version: "3.11"
+          local-channel: /tmp/local-channel
+          package-name: ${{ env.PKG_NAME }}=${{ env.PKG_VERSION }} # install exact version
+          extra-channels: neutrons mantid
+          extra-commands: |
+            python -c "import lr_reduction"
+            python -c "import lr_autoreduce"
+            python -c "import mantid"
 
       - name: upload conda package as artifact
         uses: actions/upload-artifact@v6
@@ -83,56 +102,9 @@ jobs:
           name: artifact-conda-package
           path: ${{ env.PKG_NAME }}-*.conda
 
-  conda-verify:
-    needs: build
-    runs-on: ubuntu-24.04
-    defaults:
-      run:
-        shell: bash -el {0}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-          ref: ${{ github.ref }}
-
-      - name: Setup micromamba
-        uses: mamba-org/setup-micromamba@v2
-        with:
-          environment-name: test
-          init-shell: bash
-          create-args: >-
-            python=3.11
-
-      - name: Download conda package artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: artifact-conda-package
-          path: /tmp/local-channel/linux-64
-
-      - name: Install the package
-        run: |
-          micromamba install --yes -c conda-forge conda-build conda-index
-          python -m conda_index /tmp/local-channel
-          micromamba install --yes -c /tmp/local-channel -c mantid -c neutrons -c conda-forge ${{ env.PKG_NAME }}
-
-      - name: Verify the installation
-        run: |
-          conda_version=$(micromamba list "${{ env.PKG_NAME }}" | awk -v pkg="${{ env.PKG_NAME }}" '$1 == pkg { print $2 }')
-          echo "Conda version: $conda_version"
-          python_version=$(python -c "import ${{ env.PKG_NAME }}; print(${{ env.PKG_NAME }}.__version__)")
-          echo "Python version: $python_version"
-          if [ "$conda_version" != "$python_version" ]; then
-            echo "Version mismatch!"
-            exit 1
-          else
-            echo "Versions match."
-          fi
-
   publish:
     runs-on: ubuntu-24.04
-    needs: [tests, build, conda-verify]
+    needs: [tests, build]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
@@ -144,8 +116,6 @@ jobs:
 
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
-        with:
-          pixi-version: v0.48.2
 
       - name: Download conda package artifact
         uses: actions/download-artifact@v7
@@ -166,7 +136,7 @@ jobs:
   # Trigger GitLab dev deploy pipeline
   deploy-dev:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [tests, build]
     if: github.ref == 'refs/heads/next'
     steps:
       - name: Get Environment Name

--- a/pixi.lock
+++ b/pixi.lock
@@ -3456,10 +3456,9 @@ packages:
   timestamp: 1753035921043
 - pypi: ./
   name: lr-reduction
-  version: 2.8.0.dev21
-  sha256: 7367f6223125e9d2b9d3cdadfaeef734a15fb6aa536bd8fe0435443f4574f4cb
+  version: 2.8.0.dev16
+  sha256: 8a482c2d48aded4f1c83f8d2d8380905aa3934768e6334dbcf32a716aae565f6
   requires_python: '>=3.11'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   md5: 9de5350a85c4a20c685259b889aa6393

--- a/pixi.lock
+++ b/pixi.lock
@@ -3456,8 +3456,8 @@ packages:
   timestamp: 1753035921043
 - pypi: ./
   name: lr-reduction
-  version: 2.8.0.dev16
-  sha256: 8a482c2d48aded4f1c83f8d2d8380905aa3934768e6334dbcf32a716aae565f6
+  version: 2.8.0.dev19
+  sha256: f23aa8b0be753c8e5d518c61810d32534cd0146477501c54a00fdfa5101338f9
   requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ name = "lr_reduction"
 version = "0.0.0"  # a placeholder overwritten when Pixi task "sync-version" is executed
 
 [tool.pixi.package.build]
-backend = { name = "pixi-build-python", version = "*" }
+backend = { name = "pixi-build-python", version = ">=0.2,<1" }
 
 [tool.pixi.package.host-dependencies]
 hatchling= ">=1.27.0,<2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ name = "lr_reduction"
 version = "0.0.0"  # a placeholder overwritten when Pixi task "sync-version" is executed
 
 [tool.pixi.package.build]
-backend = { name = "pixi-build-python", version = "0.1.*" }
+backend = { name = "pixi-build-python", version = "*" }
 
 [tool.pixi.package.host-dependencies]
 hatchling= ">=1.27.0,<2"


### PR DESCRIPTION
## Description of work:

Change the conda verify step to use the action `conda-verify` and add an extra command to check that after installing the conda package `lr_reduction`, one can also import the new package `lr_autoreduce`.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
