### PR TITLE
rename typing and use pipe syntax instead of Union

### DIFF
--- a/src/lr_reduction/data_info.py
+++ b/src/lr_reduction/data_info.py
@@ -8,7 +8,7 @@ import numpy as np
 from mantid.simpleapi import logger
 
 from lr_reduction.mantid_utils import SampleLogValues
-from lr_reduction.typing import MantidWorkspace
+from lr_reduction.types import MantidWorkspace
 
 
 class DataType(IntEnum):

--- a/src/lr_reduction/gravity_correction.py
+++ b/src/lr_reduction/gravity_correction.py
@@ -2,7 +2,7 @@ from enum import IntEnum
 
 import numpy as np
 
-from lr_reduction.typing import MantidWorkspace
+from lr_reduction.types import MantidWorkspace
 from lr_reduction.utils import workspace_handle
 
 

--- a/src/lr_reduction/mantid_utils.py
+++ b/src/lr_reduction/mantid_utils.py
@@ -1,4 +1,4 @@
-from lr_reduction.typing import MantidWorkspace
+from lr_reduction.types import MantidWorkspace
 from lr_reduction.utils import workspace_handle
 
 

--- a/src/lr_reduction/template.py
+++ b/src/lr_reduction/template.py
@@ -13,7 +13,7 @@ from mantid.simpleapi import logger
 from lr_reduction import event_reduction, peak_finding, reduction_template_reader
 from lr_reduction.instrument_settings import InstrumentSettings
 from lr_reduction.reduction_template_reader import ReductionParameters
-from lr_reduction.typing import MantidWorkspace
+from lr_reduction.types import MantidWorkspace
 
 TOLERANCE = 0.07
 OUTPUT_NORM_DATA = False

--- a/src/lr_reduction/types.py
+++ b/src/lr_reduction/types.py
@@ -1,0 +1,3 @@
+from mantid.api import Workspace
+
+MantidWorkspace = str | Workspace

--- a/src/lr_reduction/typing.py
+++ b/src/lr_reduction/typing.py
@@ -1,5 +1,0 @@
-from typing import Union
-
-from mantid.api import Workspace
-
-MantidWorkspace = Union[str, Workspace]

--- a/src/lr_reduction/utils.py
+++ b/src/lr_reduction/utils.py
@@ -6,7 +6,7 @@ from typing import Union
 from mantid.kernel import ConfigService
 from mantid.simpleapi import mtd
 
-from lr_reduction.typing import MantidWorkspace
+from lr_reduction.types import MantidWorkspace
 
 
 def mantid_algorithm_exec(algorithm_class, **kwargs):

--- a/src/lr_reduction/web_report.py
+++ b/src/lr_reduction/web_report.py
@@ -17,7 +17,7 @@ from lr_reduction import template
 from lr_reduction.data_info import DataType
 from lr_reduction.mantid_utils import SampleLogValues
 from lr_reduction.reduction_template_reader import ReductionParameters
-from lr_reduction.typing import MantidWorkspace
+from lr_reduction.types import MantidWorkspace
 
 XY_PLOT_ZOOM_X_RANGE = [25, 225]
 XY_PLOT_ZOOM_Y_RANGE = [100, 200]

--- a/src/lr_reduction/workflow.py
+++ b/src/lr_reduction/workflow.py
@@ -9,7 +9,7 @@ import numpy as np
 from mantid.simpleapi import LoadEventNexus, logger
 
 from lr_reduction import event_reduction, output, reduction_template_reader, template
-from lr_reduction.typing import MantidWorkspace
+from lr_reduction.types import MantidWorkspace
 from lr_reduction.web_report import assemble_report, generate_report_sections
 
 


### PR DESCRIPTION
Quick patch to address a recent issue where `from typing import Union` throws an exception due to overshadowing a standard library 