### PR TITLE
Add AbsoluteNormalization Stitching Type

### DIFF
--- a/src/lr_reduction/output.py
+++ b/src/lr_reduction/output.py
@@ -61,7 +61,8 @@ class RunCollection:
         Calculate scale factors for each run in the collection
         """
 
-        if self.stitching_configuration.type == StitchingType.NONE:
+        if (self.stitching_configuration.type == StitchingType.NONE
+                or self.stitching_configuration.type == StitchingType.ABSOLUTE_NORMALIZATION):
             return
         elif self.stitching_configuration.type == StitchingType.AUTOMATIC_AVERAGE:
 

--- a/src/lr_reduction/stitching.py
+++ b/src/lr_reduction/stitching.py
@@ -9,8 +9,9 @@ from mantid.simpleapi import CreateWorkspace, Fit, ReplaceSpecialValues, logger
 
 class StitchingType(Enum):
     """Enum for stitching types"""
-    NONE = "None"
+    NONE = "None" # Maps to 'manual'
     AUTOMATIC_AVERAGE = "AutomaticAverage"
+    ABSOLUTE_NORMALIZATION = "AbsoluteNormalization"
 
     @classmethod
     def from_value(cls, value: str):

--- a/tests/unit/lr_reduction/test_stitching_type.py
+++ b/tests/unit/lr_reduction/test_stitching_type.py
@@ -11,6 +11,7 @@ class TestStitchingType:
         """Test that StitchingType enum has correct values"""
         assert StitchingType.NONE.value == "None"
         assert StitchingType.AUTOMATIC_AVERAGE.value == "AutomaticAverage"
+        assert StitchingType.ABSOLUTE_NORMALIZATION.value == "AbsoluteNormalization"
 
     def test_from_value_none(self):
         """Test from_value with None input"""
@@ -27,12 +28,19 @@ class TestStitchingType:
         result = StitchingType.from_value("automaticaverage")
         assert result == StitchingType.AUTOMATIC_AVERAGE
 
+    def test_from_value_absolute_normalization(self):
+        """Test from_value with 'automaticaverage' string"""
+        result = StitchingType.from_value("AbsoluteNormalization")
+        assert result == StitchingType.ABSOLUTE_NORMALIZATION
+
     def test_from_value_case_insensitive(self):
         """Test that from_value is case insensitive"""
         assert StitchingType.from_value("NONE") == StitchingType.NONE
         assert StitchingType.from_value("None") == StitchingType.NONE
         assert StitchingType.from_value("AutomaticAverage") == StitchingType.AUTOMATIC_AVERAGE
         assert StitchingType.from_value("AUTOMATICAVERAGE") == StitchingType.AUTOMATIC_AVERAGE
+        assert StitchingType.from_value("absolutenormalization") == StitchingType.AUTOMATIC_AVERAGE
+        assert StitchingType.from_value("ABSOLUTENORMALIZATION") == StitchingType.ABSOLUTE_NORMALIZATION
 
     def test_from_value_invalid(self):
         """Test that from_value raises ValueError for invalid input"""

--- a/tests/unit/lr_reduction/test_stitching_type.py
+++ b/tests/unit/lr_reduction/test_stitching_type.py
@@ -39,7 +39,7 @@ class TestStitchingType:
         assert StitchingType.from_value("None") == StitchingType.NONE
         assert StitchingType.from_value("AutomaticAverage") == StitchingType.AUTOMATIC_AVERAGE
         assert StitchingType.from_value("AUTOMATICAVERAGE") == StitchingType.AUTOMATIC_AVERAGE
-        assert StitchingType.from_value("absolutenormalization") == StitchingType.AUTOMATIC_AVERAGE
+        assert StitchingType.from_value("absolutenormalization") == StitchingType.ABSOLUTE_NORMALIZATION
         assert StitchingType.from_value("ABSOLUTENORMALIZATION") == StitchingType.ABSOLUTE_NORMALIZATION
 
     def test_from_value_invalid(self):


### PR DESCRIPTION
## Description of work:
Adds the `AbsoluteNormalization` stitching type to be compatible with refred front end

Check all that apply:
- [ ] updated documentation
- [X] Source added/refactored
- [X] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [13788: [lr_reduction] Add option to use automatic stitching](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/13788)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
