### PR TITLE
Interpret *:CS:Autoreduce:ScaleMultiplier in log_values{} and DB

### DIFF
--- a/launcher/apps/direct_beam.py
+++ b/launcher/apps/direct_beam.py
@@ -1,26 +1,22 @@
 #!/usr/bin/python3
 import os
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
 from qtpy import QtCore
 from qtpy.QtWidgets import (
-    QFileDialog,
-    QGridLayout,
+    QCheckBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
     QLabel,
-    QPushButton,
-    QWidget,
     QLineEdit,
     QMessageBox,
-    QHBoxLayout,
+    QPushButton,
     QVBoxLayout,
-    QCheckBox,
-    QGroupBox,
-    QFormLayout,
-    QSpinBox,
-    QDoubleSpinBox,
+    QWidget,
 )
-
-import numpy as np
-from matplotlib.figure import Figure
-import matplotlib.pyplot as plt
 
 # Try matplotlib Qt backends
 FigureCanvas = None
@@ -57,7 +53,7 @@ class CdSettingsDialog(QMessageBox):
     def __init__(self, parent=None, defaults=None, initial_defaults=None):
         super().__init__(parent)
         # Using simple dialog via QMessageBox with custom widget is cumbersome; build a QDialog-like widget
-        from qtpy.QtWidgets import QDialog, QFormLayout, QDialogButtonBox
+        from qtpy.QtWidgets import QDialog, QDialogButtonBox, QFormLayout
         self.dlg = QDialog(parent)
         self.dlg.setWindowTitle("Cd settings")
         layout = QVBoxLayout()
@@ -132,7 +128,7 @@ class CdSettingsDialog(QMessageBox):
 
 class ModeratorDialog(QMessageBox):
     def __init__(self, parent=None, defaults=None, initial_defaults=None):
-        from qtpy.QtWidgets import QDialog, QFormLayout, QDialogButtonBox
+        from qtpy.QtWidgets import QDialog, QDialogButtonBox, QFormLayout
         super().__init__(parent)
         self.dlg = QDialog(parent)
         self.dlg.setWindowTitle('Moderator settings')
@@ -561,4 +557,4 @@ class DirectBeamTab(QWidget):
                 plt.ylabel('I')
                 plt.tight_layout()
                 plt.show()
- 
+

--- a/launcher/apps/overplot.py
+++ b/launcher/apps/overplot.py
@@ -1,24 +1,23 @@
 #!/usr/bin/python3
 import os
-from qtpy import QtCore, QtGui, QtWidgets
-from qtpy.QtWidgets import (
-    QFileDialog,
-    QGridLayout,
-    QLabel,
-    QListWidget,
-    QListWidgetItem,
-    QPushButton,
-    QComboBox,
-    QWidget,
-    QLineEdit,
-    QMessageBox,
-    QHBoxLayout,
-    QVBoxLayout,
-)
 
+import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.figure import Figure
-import matplotlib.pyplot as plt
+from qtpy import QtCore
+from qtpy.QtWidgets import (
+    QComboBox,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 # Try a few possible Qt backends for matplotlib (Qt5, QtAgg, Qt4)
 FigureCanvas = None

--- a/launcher/apps/roi_selector.py
+++ b/launcher/apps/roi_selector.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
 import os
+
 import h5py
 import numpy as np
-import traceback
+
 # Try to import scipy curve fit for better peak finding (optional)
 try:
     from scipy.optimize import curve_fit
@@ -13,14 +14,29 @@ except Exception:
 # Qt and Matplotlib imports (some are optional depending on environment)
 try:
     from qtpy import QtCore
+    from qtpy.QtGui import QBrush, QColor, QFont
     from qtpy.QtWidgets import (
-        QDialog, QWidget, QVBoxLayout, QFormLayout, QHBoxLayout, QLineEdit,
-        QPushButton, QDialogButtonBox, QFileDialog, QCheckBox, QTableWidget,
-        QTableWidgetItem, QComboBox, QLabel, QSpinBox, QListWidget, QGroupBox,
-        QSizePolicy, QGridLayout
+        QCheckBox,
+        QComboBox,
+        QDialog,
+        QDialogButtonBox,
+        QFileDialog,
+        QFormLayout,
+        QGridLayout,
+        QGroupBox,
+        QHBoxLayout,
+        QLabel,
+        QLineEdit,
+        QListWidget,
+        QMessageBox,
+        QPushButton,
+        QSizePolicy,
+        QSpinBox,
+        QTableWidget,
+        QTableWidgetItem,
+        QVBoxLayout,
+        QWidget,
     )
-    from qtpy.QtWidgets import QMessageBox
-    from qtpy.QtGui import QFont, QBrush, QColor
 except Exception:
     # allow headless import failures; variables below will be None/missing and
     # the rest of the code should guard against unavailable GUI elements.
@@ -30,17 +46,18 @@ except Exception:
         QtCore = None
 
 try:
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas, NavigationToolbar2QT as NavigationToolbar
-    from matplotlib.figure import Figure
     import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+    from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
     from matplotlib.colors import LogNorm
+    from matplotlib.figure import Figure
 except Exception:
     FigureCanvas = None
     NavigationToolbar = None
     Figure = None
     plt = None
     LogNorm = None
-    
+
 class DBPerRunDialog(QDialog):
     """Simple dialog to edit per-run DB_file and q_method lists."""
     def __init__(self, parent=None, runs=None, initial=None, q_initial=None):
@@ -91,7 +108,7 @@ class DBPerRunDialog(QDialog):
             except Exception:
                 qs.append('')
         return {'db_files': dbs, 'q_methods': qs}
-    
+
 class SaveTemplateDialog(QDialog):
     def __init__(self, parent=None, defaults=None, runs=None):
         super().__init__(parent)
@@ -2247,4 +2264,4 @@ class ROISelector(QWidget):
             QMessageBox.critical(self, "Save error", f"Failed to save combined template: {e}")
 
 
-    
+

--- a/launcher/apps/template_batch.py
+++ b/launcher/apps/template_batch.py
@@ -3,24 +3,24 @@ import os
 import threading
 from pathlib import Path
 
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtWidgets
 from qtpy.QtWidgets import (
+    QCheckBox,
     QFileDialog,
     QGridLayout,
     QLabel,
+    QLineEdit,
     QMessageBox,
     QPushButton,
-    QCheckBox,
-    QLineEdit,
-    QDialog,
-    QWidget,
     QSpinBox,
+    QWidget,
 )
+
 try:
     # Use QtAgg canvas for embedding matplotlib figures
+    import matplotlib.pyplot as plt
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
     from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
-    import matplotlib.pyplot as plt
 except Exception:
     FigureCanvas = None
     NavigationToolbar = None
@@ -581,7 +581,7 @@ class TemplateBatchTab(QWidget):
             raise ValueError("Please specify runs to process")
         try:
             runs = parse_run_list(runs_text)
-        except Exception as e:
+        except Exception:
             raise
 
         expt = self.experiment_edit.text().strip()

--- a/launcher/launcher.py
+++ b/launcher/launcher.py
@@ -8,9 +8,6 @@ from apps.quick_reduce import QuickReduce
 from apps.reduction import Reduction
 from apps.sld_calculator import SLD
 from apps.xrr import XRR
-from apps.overplot import Overplot
-from apps.roi_selector import ROISelector
-from apps.direct_beam import DirectBeamTab
 from qtpy import QtCore
 from qtpy.QtWidgets import QApplication, QGridLayout, QTabWidget, QWidget
 

--- a/launcher/new_launcher.py
+++ b/launcher/new_launcher.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 import sys
 
-from apps.sld_calculator import SLD
+from apps.direct_beam import DirectBeamTab
 from apps.overplot import Overplot
 from apps.roi_selector import ROISelector
-from apps.direct_beam import DirectBeamTab
+from apps.sld_calculator import SLD
 from apps.template_batch import TemplateBatchTab
 from qtpy import QtCore
 from qtpy.QtWidgets import QApplication, QGridLayout, QTabWidget, QWidget

--- a/src/lr_reduction/EBW_nr_reduction_test.py
+++ b/src/lr_reduction/EBW_nr_reduction_test.py
@@ -5,10 +5,9 @@ Example usage of the unified NR reduction class
 Demonstrates how to configure and run reductions using both constantQ, constantTOF and MeanTheta methods
 """
 
+import numpy as np
 from nr_reduction_calc import NR_Reduction
 from nr_reduction_config import NRReductionConfig
-import numpy as np
-
 
 
 def test_mean_theta_reduction():
@@ -16,11 +15,11 @@ def test_mean_theta_reduction():
     print("\n" + "="*60)
     print("MEAN THETA REDUCTION EXAMPLE")
     print("="*60)
-    
+
     # Create configuration for MeanTheta method
     config = NRReductionConfig(method='meanTheta')
-    
-    # Path needs to be setup for these tests but should be able to turn off later.    
+
+    # Path needs to be setup for these tests but should be able to turn off later.
     config.Spath = '/SNS/REF_L/shared/lr_reduction/EBW_tests/'
     #config.NEXUSpathRB = # Append path if required.
     config.DBpath = '/SNS/REF_L/shared/Cd_DB_processing/DBs/'
@@ -47,41 +46,41 @@ def test_mean_theta_reduction():
     # Output name
     config.Sname = "210975_meanTheta"
 
-    
+
     config.dqbin = 0.005
     config.dMod = 15500.0
     config.dS1Samp = 1450.0
     config.dSampDet = 1830.0
-    
+
     config.tof_bin = 50
     config.dead_time = 4.2
     #config.data_x_range = [0,255]
-    
+
     config.LambdaMin = [2.5,2.5,2.5]
     config.LambdaMax = [9.6,9.6,9.6]
-    
+
     #config.useBS = [False,False,False]
-    
-    
+
+
     # Processing options
     config.Normalize = True
     config.AutoScale = True
     config.useCalcTheta = True
     config.plotON = True  # Set to False for batch processing
-    
+
     # Method-specific parameters
     config.peak_pad = 1
     config.Qline_threshold = 1.0
     config.DetSigma = 0.8
     config.DetResFn = 'rectangular'
-    
+
     # Run reduction
     reducer = NR_Reduction(config)
     results = reducer.reduce()
-    
+
     print(f"\nReduced {len(config.RBnum)} runs with repeat averaging")
     print(f"Q range: {results['Q'].min():.4f} - {results['Q'].max():.4f} Å⁻¹")
-    
+
     return results
 
 
@@ -90,11 +89,11 @@ def test_constant_tof_reduction():
     print("\n" + "="*60)
     print("CONSTANT TOF REDUCTION EXAMPLE")
     print("="*60)
-    
+
     # Create configuration for constantTOF method
     config = NRReductionConfig(method='constantTOF')
-    
-    # Path needs to be setup for these tests but should be able to turn off later.    
+
+    # Path needs to be setup for these tests but should be able to turn off later.
     config.Spath = '/SNS/REF_L/shared/lr_reduction/EBW_tests/'
     #config.NEXUSpathRB = # Append path if required.
     config.DBpath = '/SNS/REF_L/shared/Cd_DB_processing/DBs/'
@@ -117,40 +116,40 @@ def test_constant_tof_reduction():
         RB_Ymax + 3,
         RB_Ymax + 8
     ))
-    
+
     # Output name
     config.Sname = "211029_constantTOF"
-    
-    
+
+
     config.dqbin = 0.005
     config.dMod = 15500.0
     config.dS1Samp = 1450.0
     config.dSampDet = 1830.0
-    
+
     config.tof_bin = 50
     config.dead_time = 4.2
     #config.data_x_range = [0,255]
-    
+
     config.LambdaMin = [2.5,2.5,2.5]
     config.LambdaMax = [9.6,9.6,9.6]
-    
+
     # Processing options
     config.Normalize = False
     config.AutoScale = False
     config.useCalcTheta = False
     config.plotON = True
-    
+
     # Method-specific parameters
     config.peak_pad = 1
     config.plotQ4 = False  # ConstantTOF typically doesn't plot Q4
-    
+
     # Run reduction
     reducer = NR_Reduction(config)
     results = reducer.reduce()
-    
+
     print(f"\nReduced {len(config.RBnum)} runs (TOF-binned)")
     print(f"Q range: {results['Q'].min():.4f} - {results['Q'].max():.4f} Å⁻¹")
-    
+
     return results
 
 
@@ -161,4 +160,4 @@ if __name__ == '__main__':
     test_mean_theta_reduction()
     #test_constant_tof_reduction()
 
-    
+

--- a/src/lr_reduction/binary_processing.py
+++ b/src/lr_reduction/binary_processing.py
@@ -147,8 +147,19 @@ def get_log_values(fname):
     log_values["thi"] = f['entry/DASlogs/BL4B:Mot:thi.RBV/value'][-1]
     log_values["ths"] = f['entry/DASlogs/BL4B:Mot:ths.RBV/value'][-1]
     log_values["tthd"] = f['entry/DASlogs/BL4B:Mot:tthd.RBV/value'][-1]
+    # Autoreduction indicators
     log_values["seq_num"] = f['entry/DASlogs/BL4B:CS:Autoreduce:Sequence:Num/value'][0]
     log_values["seq_id"] = f['entry/DASlogs/BL4B:CS:Autoreduce:Sequence:Id/value'][0]
+    try:
+        #log_values["seq_total"] = f['entry/DASlogs/BL4B:CS:Autoreduce:Sequence:Total/value'][0]
+        #log_values["center_pixel"] = f['entry/DASlogs/BL4B:CS:Autoreduce:Sequence:CenterPixel/value'][0]
+        #log_values["data_type"] = f['entry/DASlogs/BL4B:CS:Autoreduce:Sequence:DataType/value'][0]
+        log_values["scale_multiplier"] = f['entry/DASlogs/BL4B:CS:Autoreduce:ScaleMultiplier/value'][0]
+        #log_values["distance_sample_detector"] = f['entry/DASlogs/BL4B:CS:Autoreduce:Sequence:DistanceSampleDetector/value'][0]
+        #log_values["template_id"] = f['entry/DASlogs/BL4B:CS:Autoreduce:Sequence:TemplateId/value'][0]
+    except Exception as e:
+        print(f'Cannot process {fname} b/c {e} fails to extract')
+        pass
     # Get slit gap openings.
     log_values["siY"]=np.array(f['entry/DASlogs/BL4B:Mot:si:Y:Gap:Readback/average_value'][0])
     log_values["s1Y"]=np.array(f['entry/DASlogs/BL4B:Mot:s1:Y:Gap:Readback/average_value'][0])

--- a/src/lr_reduction/binary_processing.py
+++ b/src/lr_reduction/binary_processing.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy.special import lambertw
 
 ## NOTES: This moves away from events after the dead-time correction has been applied.
-## Various aspects of this are easier through h5py than mantid wksp. Here will include a few functions to 
+## Various aspects of this are easier through h5py than mantid wksp. Here will include a few functions to
 ## work through the steps which might not all be needed in the final version but shows the idea.
 
 # TODO: link up the parts that are self. from copying across.
@@ -11,7 +11,7 @@ from scipy.special import lambertw
 def convert_to_binary(fname, lowres, collapse_x = True, tofbin=50, tofmax=100000, tofmin=0, deadtime=4.2, tof_step=100, n_y=304, n_x=256):
     '''
     Main function for converting to load the file, apply the dead-time correction and obtain y vs tof data (non-event).
-    
+
     :param fname: File to load
     :param lowres: pixel range for low-res direction (i.e. x-pixels for LR). expects of format [min, max]
     :param collapse_x: planned option to keep the x-pixel direction but not implemented. True sums over x-pixels in the lowres range.
@@ -54,7 +54,7 @@ def load_and_extract(fname):
     pcharge=np.array(f['entry/proton_charge'][:])
     # This is single value. TODO: streamline so don't need this and the previous log.
     cPC=np.array(f['entry/DASlogs/proton_charge/value'][:])
-    
+
     log_values = get_log_values(fname)
 
     return e_offset, event_id, error_event_offset, pcharge, cPC, log_values
@@ -63,7 +63,7 @@ def load_and_extract(fname):
 def get_deadtime_correction(error_event_offset, e_offset, pcharge, tofbin=50, tofmax=50000, tofmin=0, use_bad_counts=True, deadtime=4.2, tof_step=100):
     '''
     Gets and applies the dead-time correction.
-    
+
     :param error_event_offset: Description
     :param e_offset: Description
     :param pcharge: Description
@@ -82,7 +82,7 @@ def get_deadtime_correction(error_event_offset, e_offset, pcharge, tofbin=50, to
     bin_edges = np.concatenate([[tof_array[0] - tofbin/2], tof_array + tofbin/2])
     # Fill with the event time offsets
     counts, _ = np.histogram(e_offset, bins=bin_edges)
-    
+
     if use_bad_counts:
         # Include the bad counts for dead-time correction
         bad_counts, _ = np.histogram(error_event_offset, bins=bin_edges)
@@ -92,7 +92,7 @@ def get_deadtime_correction(error_event_offset, e_offset, pcharge, tofbin=50, to
     # Normalise by proton charge
     counts_norm = counts / pGood
 
-    # Calculate the dead-time correction - this links to existing expression and properties.   
+    # Calculate the dead-time correction - this links to existing expression and properties.
     with np.errstate(divide='ignore', invalid='ignore'):
         b = -lambertw(-counts_norm * deadtime / tofbin) / (deadtime / tofbin)
         DTC = np.real(b / counts_norm)
@@ -103,7 +103,7 @@ def get_deadtime_correction(error_event_offset, e_offset, pcharge, tofbin=50, to
 def get_y_tof(tof_array, event_id, e_offset, lowres, pcharge, n_y = 304, n_x = 256):
     '''
     Collapses the event data into y vs tof histogram.
-    
+
     :param tof_array: array of tof
     :param event_id: array of event ids
     :param e_offset: array of event time offsets
@@ -179,7 +179,7 @@ def get_log_values(fname):
     # TODO: check if we need any of the other chopper parts.
     log_values["frequency"]=np.array(f['entry/DASlogs/BL4B:Det:TH:BL:Frequency/value'][0])
     log_values["lam_request"]=np.array(f['entry/DASlogs/BL4B:Det:TH:BL:Lambda/value'][0])
-    
+
     try:
         log_values["chopper_mod"]=np.array(f['entry/DASlogs/BL4B:Chop:Skf2:ChopperModerator/value'][0])
     except:
@@ -191,7 +191,7 @@ def get_log_values(fname):
     log_values["emission_coefficients"]=np.array([off/1000, mult/1000])
 
     log_values["chop2_PD"] = np.array(f['entry/DASlogs/BL4B:Chop:Skf2:PhaseAccuracy/average_value'][0])
-        
+
     # TODO: Test these!!
     try:
         atten_menu = np.array(f['entry/DASlogs/BL4B:Actuator:Menu/value'][0])
@@ -218,10 +218,9 @@ def get_log_values(fname):
         Att1 = np.array(f['entry/DASlogs/BL4B:Actuator:50MRb/average_value'][0])
         Att2 = np.array(f['entry/DASlogs/BL4B:Actuator:100MRb/average_value'][0])
         Att3 = np.array(f['entry/DASlogs/BL4B:Actuator:200MRb/average_value'][0])
-        Att4 = np.array(f['entry/DASlogs/BL4B:Actuator:400MRb/average_value'][0])       
+        Att4 = np.array(f['entry/DASlogs/BL4B:Actuator:400MRb/average_value'][0])
         log_values['Atten'] = np.array([Att1,Att2,Att3,Att4])
 
     f.close()
-    
-    return log_values
 
+    return log_values

--- a/src/lr_reduction/direct_beam_maker.py
+++ b/src/lr_reduction/direct_beam_maker.py
@@ -167,7 +167,7 @@ class Direct_Beam:
                 n = log_values["scale_multiplier"]
                 print(f'Using {n} as scale multiplier')
             except Exception as e:
-                print(f'Using 1.0 as scale multiplier b/c {e}')
+                print(f'Using 1.0 as scale multiplier b/c {e} not in {repr(log_values)}')
                 n = 1.0
 
             I_trans = I / trans

--- a/src/lr_reduction/direct_beam_maker.py
+++ b/src/lr_reduction/direct_beam_maker.py
@@ -161,14 +161,23 @@ class Direct_Beam:
             mu = np.interp(L, L_ENDF, mu_ENDF)
             trans = np.exp(-mu*Cd_thickness)
 
+            # Need to interpret the scale multiplier and apply the correction
+            # This allows the program to handle slit-scan DBs
+            try:
+                n = log_values["scale_multiplier"]
+                print(f'Using {n} as scale multiplier')
+            except Exception as e:
+                print(f'Using 1.0 as scale multiplier b/c {e}')
+                n = 1.0
+
             I_trans = I / trans
             if plot:
                 plt.plot(L, I_trans, 'o', markersize=1)
             # store trace for optional return
             traces.append((L, I_trans, run))
             LAM.extend(L)
-            INT.extend(I_trans)
-            ERR.extend(E/trans)
+            INT.extend(I_trans * n * n)
+            ERR.extend((E * n * n)/trans)
 
         LAM = np.array(LAM)
         INT = np.array(INT)

--- a/src/lr_reduction/direct_beam_maker.py
+++ b/src/lr_reduction/direct_beam_maker.py
@@ -1,9 +1,11 @@
-import binary_processing as BP
-from pathlib import Path
 import os
+from pathlib import Path
+
+import binary_processing as BP
+import nr_tools as tools
 import numpy as np
 from matplotlib import pyplot as plt
-import nr_tools as tools
+
 
 class Direct_Beam:
 
@@ -28,9 +30,9 @@ class Direct_Beam:
             self.NEXUSpath = f"/SNS/REF_L/{self.experiment_id}/nexus/"
             self.savepath = f"/SNS/REF_L/{self.experiment_id}/shared/transmission/"
         #self.Cd_foils = [57.5, 126.5, 123.0]      #microns for 50, 100A, 100B Cd foils
-        self.Cd = [57.5, 
-            126.5, 
-            126.5+123.0, 
+        self.Cd = [57.5,
+            126.5,
+            126.5+123.0,
             2*126.5+2*123.0] #microns Cd for each attenuator
         self.Chop2_cut_fn = [2.077, -16818.0]        # linear fit to chopper cut time
         self.Icut = 1e-10                 # threshold cut off any data below Icut (noisy)
@@ -152,12 +154,12 @@ class Direct_Beam:
             T, I, E, DTC = self._trim_and_chop(T, I, E, DTC, log_values["chop2_PD"], lowest = low_tag)
             T = T * 1e-3 # convert to ms
             #print(f'Run {run}: After trimming and chopping, {len(T)} points remain')
-    
+
             # TODO: use logic from nr_reduction_calc
             # convert to Lambda
             L=3956*T/self.dMod
             L=3956*(T-(self.t0[0]+self.t0[1]*L))/self.dMod
-            
+
             mu = np.interp(L, L_ENDF, mu_ENDF)
             trans = np.exp(-mu*Cd_thickness)
 
@@ -216,7 +218,7 @@ class Direct_Beam:
 
     def _calc_average_db_pixel(self, db_pixel_list, tthd):
         """
-        Wrapper to calculate the average DB pixel position and its standard deviation, 
+        Wrapper to calculate the average DB pixel position and its standard deviation,
         as well as the average tthd and its standard deviation for use in header.
         """
         MeanPos = np.round(np.mean(db_pixel_list),2)
@@ -268,14 +270,14 @@ class Direct_Beam:
 
         if flip_atten:
             Atten = np.floor(1 - Atten)
-    
-        Cd_thickness = (self.Cd[0] * Atten[0] + 
+
+        Cd_thickness = (self.Cd[0] * Atten[0] +
                         self.Cd[1] * Atten[1] +
                         self.Cd[2] * Atten[2] +
                         self.Cd[3] * Atten[3])* 1e-4  #cm
 
         return Cd_thickness
-    
+
     def _trim_and_chop(self, T, I, E, DTC, chop2_phase, lowest = False):
 
         # trim off points that drop below the intensity threshold

--- a/src/lr_reduction/example_direct_beam.py
+++ b/src/lr_reduction/example_direct_beam.py
@@ -2,10 +2,11 @@
 Example usage of the Direct_Beam class
 """
 
-from lr_reduction.direct_beam_maker import Direct_Beam
 import numpy as np
 
-db = Direct_Beam()  
+from lr_reduction.direct_beam_maker import Direct_Beam
+
+db = Direct_Beam()
 
 # Example usage
 db.savepath = '/SNS/REF_L/shared/lr_reduction/new_workflow_test_outputs/'  # Set the directory where you want to save the output
@@ -13,9 +14,9 @@ db.NEXUSpath = '/SNS/REF_L/IPTS-36119/nexus/'  # Set the path to your Nexus file
 db.Chop2_cut_fn = [2.077, -16818.0]
 db.DTCcut = 1.25
 db.DTCcut_config1 = 1.8
-#DB_out = db.create_db(run_list=[226473,226474,226475,226476], save_name='direct_beam_test.dat', 
+#DB_out = db.create_db(run_list=[226473,226474,226475,226476], save_name='direct_beam_test.dat',
 #                      plot=True)
 
 run_list = np.arange(225318,225321+1)
-DB_out = db.create_db(run_list=run_list, save_name='direct_beam_test.dat', 
+DB_out = db.create_db(run_list=run_list, save_name='direct_beam_test.dat',
                       plot=True, flip_atten=True)

--- a/src/lr_reduction/example_nr_from_template.py
+++ b/src/lr_reduction/example_nr_from_template.py
@@ -2,17 +2,18 @@
 Example script for running new reduction with config from template (e.g. for autoreduction workflow)
 """
 
-import numpy as np
-import new_reduction_from_template as new_template
 from pathlib import Path
+
+import new_reduction_from_template as new_template
+
 
 def example_template_reduction():
     # Example for just a single angle.
-    
+
     print("\n" + "="*60)
     print("TEMPLATE REDUCTION EXAMPLE")
     print("="*60)
-    
+
     # These shouldn't be needed in the longer term.
     datapath = Path('/SNS/REF_L/IPTS-30101/nexus')
     DBpath = Path('/SNS/REF_L/shared/Cd_DB_processing/DBs/')
@@ -30,19 +31,19 @@ def example_template_reduction():
     }
 
     results = new_template.reduce_from_template(211029, template_path / "test_template.xml", "IPTS-36119", datapath=datapath, template_path=template_path, override_params=override_params, plot=True)
-   
+
     #print(f"\nReduced {len(config.RBnum)} runs")
     print(f"Q range: {results['Q'].min():.4f} - {results['Q'].max():.4f} Å⁻¹")
-    
+
     return results
 
 def example_template_reduction_3ang():
     # Example with 3 angles in a set
-    
+
     print("\n" + "="*60)
     print("TEMPLATE REDUCTION EXAMPLE")
     print("="*60)
-    
+
     datapath = Path('/SNS/REF_L/IPTS-30101/nexus')
     DBpath = Path('/SNS/REF_L/shared/Cd_DB_processing/DBs/')
     template_path = Path('/SNS/REF_L/shared/lr_reduction/new_workflow_test_outputs/')
@@ -66,20 +67,20 @@ def example_template_reduction_3ang():
         }
 
         results = new_template.reduce_from_template(run, template_path / "test_template_3ang.xml", "IPTS-36119", datapath=datapath,template_path=template_path,override_params=override_params, plot=True)
-   
+
         #print(f"\nReduced {len(config.RBnum)} runs")
         print(f"Q range: {results['Q'].min():.4f} - {results['Q'].max():.4f} Å⁻¹")
-    
+
 
     return results
 
 def example_template_reduction_new():
     # Example to redo the prior reduction but reading from the new template.
-    
+
     print("\n" + "="*60)
     print("TEMPLATE REDUCTION EXAMPLE")
     print("="*60)
-    
+
     datapath = Path('/SNS/REF_L/IPTS-30101/nexus')
     Spath = Path('/SNS/REF_L/shared/lr_reduction/new_workflow_test_outputs/')
     DBpath = Path('/SNS/REF_L/shared/Cd_DB_processing/DBs/')
@@ -96,12 +97,12 @@ def example_template_reduction_new():
             'DBpath': DBpath
         }
 
-        results = new_template.reduce_from_template(run, template_path / "REFL_211029_template_new.xml", "IPTS-36119", 
+        results = new_template.reduce_from_template(run, template_path / "REFL_211029_template_new.xml", "IPTS-36119",
                                                     datapath=datapath, template_path=template_path, override_params=override_params, plot=True)
-   
+
         #print(f"\nReduced {len(config.RBnum)} runs")
         print(f"Q range: {results['Q'].min():.4f} - {results['Q'].max():.4f} Å⁻¹")
-    
+
 
     return results
 

--- a/src/lr_reduction/example_nr_reduction.py
+++ b/src/lr_reduction/example_nr_reduction.py
@@ -5,9 +5,9 @@ Example usage of the unified NR reduction class
 Demonstrates how to configure and run reductions using both constantQ, constantTOF and MeanTheta methods
 """
 
+import numpy as np
 from nr_reduction_calc import NR_Reduction
 from nr_reduction_config import NRReductionConfig
-import numpy as np
 
 
 def example_constant_q_reduction():
@@ -15,12 +15,12 @@ def example_constant_q_reduction():
     print("\n" + "="*60)
     print("CONSTANT Q-LINE REDUCTION EXAMPLE")
     print("="*60)
-    
+
     # Create configuration for constantQ method
     config = NRReductionConfig()
     config.method_per_run = ['constantQ']
 
-    # Path needs to be setup for these tests but should be able to turn off later.    
+    # Path needs to be setup for these tests but should be able to turn off later.
     config.Spath = '/SNS/REF_L/shared/lr_reduction/new_workflow_test_outputs/'
     #config.NEXUSpathRB = # Append path if required.
     config.DBpath = '/SNS/REF_L/shared/Cd_DB_processing/DBs/'
@@ -48,24 +48,24 @@ def example_constant_q_reduction():
 
     # Output name
     config.Sname = "NR_constantQ"
-    
+
     # Processing options
     config.Normalize = False
     config.AutoScale = False
     config.useCalcTheta = True
     config.plotON = True  # Set to False for batch processing
-    
+
     # Method-specific parameters
     config.peak_pad = 5
     config.Qline_threshold = 0.66
-    
+
     # Run reduction
     reducer = NR_Reduction(config)
     results = reducer.reduce()
-    
+
     print(f"\nReduced {len(config.RBnum)} runs")
     print(f"Q range: {results['Q'].min():.4f} - {results['Q'].max():.4f} Å⁻¹")
-    
+
     return results
 
 
@@ -74,12 +74,12 @@ def example_mean_theta_reduction():
     print("\n" + "="*60)
     print("MEAN THETA REDUCTION EXAMPLE")
     print("="*60)
-    
+
     # Create configuration for MeanTheta method
     config = NRReductionConfig()
     config.method_per_run = ['meanTheta']
-    
-    # Path needs to be setup for these tests but should be able to turn off later.    
+
+    # Path needs to be setup for these tests but should be able to turn off later.
     config.Spath = '/SNS/REF_L/shared/lr_reduction/new_workflow_test_outputs/'
     #config.NEXUSpathRB = # Append path if required.
     config.DBpath = '/SNS/REF_L/shared/Cd_DB_processing/DBs/'
@@ -105,26 +105,26 @@ def example_mean_theta_reduction():
 
     # Output name
     config.Sname = "NR_meanTheta"
-    
+
     # Processing options
     config.Normalize = False
-    config.AutoScale = True 
+    config.AutoScale = True
     config.useCalcTheta = False
     config.plotON = True  # Set to False for batch processing
-    
+
     # Method-specific parameters
     config.peak_pad = 1
     config.Qline_threshold = 1.0
     config.DetSigma = 0.8
     config.DetResFn = 'rectangular'
-    
+
     # Run reduction
     reducer = NR_Reduction(config)
     results = reducer.reduce()
-    
+
     print(f"\nReduced {len(config.RBnum)} runs with repeat averaging")
     print(f"Q range: {results['Q'].min():.4f} - {results['Q'].max():.4f} Å⁻¹")
-    
+
     return results
 
 
@@ -133,12 +133,12 @@ def example_constant_tof_reduction():
     print("\n" + "="*60)
     print("CONSTANT TOF REDUCTION EXAMPLE")
     print("="*60)
-    
+
     # Create configuration for constantTOF method
     config = NRReductionConfig()
     config.method_per_run = ['constantTOF']
-    
-    # Path needs to be setup for these tests but should be able to turn off later.    
+
+    # Path needs to be setup for these tests but should be able to turn off later.
     config.Spath = '/SNS/REF_L/shared/lr_reduction/new_workflow_test_outputs/'
     #config.NEXUSpathRB = # Append path if required.
     config.DBpath = '/SNS/REF_L/shared/Cd_DB_processing/DBs/'
@@ -161,27 +161,27 @@ def example_constant_tof_reduction():
         RB_Ymax + 3,
         RB_Ymax + 8
     ))
-    
+
     # Output name
     config.Sname = "NR_constantTOF"
-    
+
     # Processing options
     config.Normalize = False
     config.AutoScale = True
     config.useCalcTheta = True
     config.plotON = True
-    
+
     # Method-specific parameters
     config.peak_pad = 1
     config.plotQ4 = False  # ConstantTOF typically doesn't plot Q4
-    
+
     # Run reduction
     reducer = NR_Reduction(config)
     results = reducer.reduce()
-    
+
     print(f"\nReduced {len(config.RBnum)} runs (TOF-binned)")
     print(f"Q range: {results['Q'].min():.4f} - {results['Q'].max():.4f} Å⁻¹")
-    
+
     return results
 
 
@@ -192,4 +192,4 @@ if __name__ == '__main__':
     example_constant_tof_reduction()
 
 
-    
+

--- a/src/lr_reduction/new_reduction_from_template.py
+++ b/src/lr_reduction/new_reduction_from_template.py
@@ -1,15 +1,17 @@
+import copy
+import os
+from pathlib import Path
+
 import h5py
+import new_reduction_template_reader as reduction_template_reader
+import nr_tools as tools
+import numpy as np
+from matplotlib import pyplot as plt
+from new_reduction_template_reader import ReductionParameters
+
 #import template
 from nr_reduction_calc import NR_Reduction  # TODO: Fix names of files!!
 from nr_reduction_config import NRReductionConfig
-from pathlib import Path
-import os
-import numpy as np
-import nr_tools as tools
-from new_reduction_template_reader import ReductionParameters
-import new_reduction_template_reader as reduction_template_reader
-from matplotlib import pyplot as plt
-import copy
 
 
 def reduce_from_template(runno, template_file, experiment_id, datapath: Path = None, template_path: Path = None, override_params: dict = None, plot=True):
@@ -27,7 +29,7 @@ def reduce_from_template(runno, template_file, experiment_id, datapath: Path = N
     Can be simplified in future.
 
     NOTE: new files for reading the template were made to not cause issues with prior setup but can be changed in future.
-    
+
     runno: reflectivity run number
     template_file: template file, including Path
     experiment_id: str IPTS number which appends to datapath if this isn't provided (e.g. "IPTS-36119")
@@ -36,7 +38,7 @@ def reduce_from_template(runno, template_file, experiment_id, datapath: Path = N
     override_params: dict  Dictionary of config settings to override the defaults in either the template reader or the NRReduction config defaults.
     plot: bool Toggle to plot outputs during reduction steps.
 
-    returns 
+    returns
         combined_results: dict of Q, R, dR, dQ. This is assembled with anything else on same seq num. #TODO: check if need individual one returned too.
     """
 
@@ -57,7 +59,7 @@ def reduce_from_template(runno, template_file, experiment_id, datapath: Path = N
     config.experiment_id = experiment_id
     config.Sname = f"REFL_{seq_id}_{seq_num}_{runno}"
     config.plotON = plot
-    
+
     if datapath:
         config.NEXUSpathRB = datapath
 
@@ -84,7 +86,7 @@ def reduce_from_template(runno, template_file, experiment_id, datapath: Path = N
     result = {'Q': results['q'], 'R': results['r'], 'dR': results['dr'], 'dQ': results['dq']}
     reduce_calc.save_results(result, sname=f"{config.Sname}_partial")
 
-    # Collect "like" runs together 
+    # Collect "like" runs together
     seq_list, run_list, combined_results, scaling_factors = assemble_results(seq_id, config.Spath, autoscale=config.AutoScale, plot=plot, RQ4=config.plotQ4)
     # Add scaling factor to output
     scale_list = np.array([np.float64(1)] + scaling_factors)
@@ -116,16 +118,16 @@ def reduce_from_template(runno, template_file, experiment_id, datapath: Path = N
 def config_from_template(template_data):
     """
     Create an NRReductionConfig from a template file.
-    
+
     Parameters
     ----------
-    template_data : 
-    
+    template_data :
+
     Returns
     -------
     NRReductionConfig
         Configuration object ready for NR_Reduction
-        
+
     """
     # NOTE: Various of the config items expect arrays so ensure is set as single item array here.
 
@@ -134,17 +136,17 @@ def config_from_template(template_data):
         method = template_data.q_method
     else:
         method = 'MeanTheta' if template_data.const_q else 'constantTOF' #TODO: decide if this should be MeanTheta or constantQ
-    
+
     # Initialize configuration
     config = NRReductionConfig()
     config.method_per_run = [method]
-    
+
     # Update other parameters from the template
     config.RB_Ymin = [template_data.data_peak_range[0]]
     config.RB_Ymax = [template_data.data_peak_range[1]]
 
     if template_data.subtract_background == True:
-        config.useBS = [1] 
+        config.useBS = [1]
     else:
         config.useBS = [0]
     config.BkgROI = [template_data.background_roi]
@@ -173,7 +175,7 @@ def config_from_template(template_data):
     config.useCalcTheta = getattr(template_data, "use_calc_theta", config.useCalcTheta)
     config.Qline_threshold = getattr(template_data, "qline_threshold", config.Qline_threshold)
     config.ScaleFactor = [getattr(template_data, "scale_factor", 1.0)]
-    
+
     return config
 
 def template_to_config(config_data, template_data):
@@ -222,7 +224,7 @@ def assemble_results(seq_id, output_dir, autoscale = True, plot=True, RQ4=False)
         seq_list, run_list, combined results
 
     """
- 
+
     # Keep track of sequence IDs and run numbers so we can make a new template
     seq_list = []
     run_list = []
@@ -282,14 +284,14 @@ def assemble_results(seq_id, output_dir, autoscale = True, plot=True, RQ4=False)
         Q.append(result[0, :])
         R.append(result[1, :])
         dR.append(result[2, :])
-        dQ.append(result[3, :])  
+        dQ.append(result[3, :])
 
         # This is a bit muddled with a few things in arrays and dict. TODO: clean-up so don't need both.
         dict_output.append({'Q': result[0,:], 'R': result[1,:], 'dR': result[2,:], 'dQ': result[3,:]})
 
     if len(Q) == 0:
         raise ValueError(f"No valid runs found for sequence {seq_id}")
-    
+
     if plot:
         plot_reflectivity(dict_output, RQ4)
 
@@ -298,7 +300,7 @@ def assemble_results(seq_id, output_dir, autoscale = True, plot=True, RQ4=False)
     R_combined = np.concatenate(R)
     dR_combined = np.concatenate(dR)
     dQ_combined = np.concatenate(dQ)
-    
+
     # Sort by Q for combined data
     idx = np.argsort(Q_combined)
     combine_results = {'Q': Q_combined[idx], 'R': R_combined[idx], 'dR': dR_combined[idx], 'dQ': dQ_combined[idx]}
@@ -407,7 +409,7 @@ def plot_reflectivity(data_array, RQ4=False, log_x = True):
     """
     Plot reflectivity assuming data_array is an array of dictionaries with keys of Q, R, dQ and dR.
     # TODO: Add error handling for not being an array or a proper dictionary.
-    
+
     :param data_array: Description
     :param RQ4: Description
     :param log_x: Description
@@ -432,4 +434,3 @@ def plot_reflectivity(data_array, RQ4=False, log_x = True):
     ax.set_xlabel('Q [1/'+Angstrom+']', fontsize=14)
     ax.set_title('NR data') # TODO: add better title handling
     plt.show()
-

--- a/src/lr_reduction/new_reduction_template_reader.py
+++ b/src/lr_reduction/new_reduction_template_reader.py
@@ -17,16 +17,16 @@ LIST OF PARAMS TO ADD:
 - useCalcTheta
 - Qline_threshold
 - Scale Factor
-- 
+-
 """
 
 import time
 import xml.dom.minidom
-from typing import Optional
 
-from lr_reduction import __version__ as VERSION
 #from lr_reduction.gravity_correction import GravityDirection
 from instrument_settings import InstrumentSettings
+
+from lr_reduction import __version__ as VERSION
 
 # Get the mantid version being used, if available
 #try:

--- a/src/lr_reduction/nr_reduction_calc.py
+++ b/src/lr_reduction/nr_reduction_calc.py
@@ -1,34 +1,33 @@
 """
 Main calculation file for reflectivity reduction. It allows for different q conversion methods.
 NR_Reduction.reduce() is main function to call from a script to process multiple runs from an array.
-NR_Reduction._reduce_single_run() is the function to call if only process a single run and want to 
+NR_Reduction._reduce_single_run() is the function to call if only process a single run and want to
 bypass the combining (e.g. for the autoreduction process).
-For now, it assumes a pre-processed DB file. 
+For now, it assumes a pre-processed DB file.
 """
+import os
+
+import binary_processing as BP
+import matplotlib.pyplot as plt
+import nr_tools as tools
 import numpy as np
-import matplotlib.pyplot as plt 
 from matplotlib.colors import LogNorm
 from scipy.ndimage import gaussian_filter1d, uniform_filter1d
-import os
-import binary_processing as BP
-import nr_tools as tools
-import datetime
-import json
 
 
 class NR_Reduction:
     """
     Main calculation file for reflectivity reduction. It allows for different q conversion methods.
     NR_Reduction.reduce() is main function to call from a script to process multiple runs from an array.
-    NR_Reduction._reduce_single_run() is the function to call if only process a single run and want to 
+    NR_Reduction._reduce_single_run() is the function to call if only process a single run and want to
     bypass the combining (e.g. for the autoreduction process).
-    For now, it assumes a pre-processed DB file. 
+    For now, it assumes a pre-processed DB file.
     """
-    
+
     def __init__(self, config):
         """
         Initialize
-        
+
         Parameters
         ----------
         config : NRReductionConfig
@@ -40,7 +39,7 @@ class NR_Reduction:
         if not self.config.method_per_run:
             self.config.method_per_run = ['meantheta'] * len(self.config.RBnum)
         self._validate_config()
-        
+
     def _validate_config(self):
         """
         Validate configuration consistency
@@ -48,7 +47,7 @@ class NR_Reduction:
         For optional arrays the defaults are set if not explicitly provided.
         """
         n_settings = len(self.config.RBnum)
-        
+
         if not self.config.DBname:
             raise ValueError("DBname must be set")
         if n_settings == 0:
@@ -61,7 +60,7 @@ class NR_Reduction:
             raise ValueError(f"If supplied, LambdaMin expects list equal to number of runs, length {n_settings}")
         if self.config.LambdaMax is not None and len(self.config.LambdaMax) != n_settings:
             raise ValueError(f"If supplied, LambdaMax expects list equal to number of runs, length {n_settings}")
-        
+
         # Method per run validation
         if len(self.config.method_per_run) == 1 and n_settings > 1:
             # If a single method is supplied for multiple runs, apply it to all runs
@@ -69,13 +68,13 @@ class NR_Reduction:
         elif self.config.method_per_run and len(self.config.method_per_run) != n_settings:
             raise ValueError(f"If supplied, method_per_run expects list equal to number of runs, length {n_settings}")
         self.config.method_per_run = [method.lower() for method in self.config.method_per_run]  # Ensure methods are lowercase
-        
+
         # Check method of valid format (meanTheta, constantQ, constantTOF)
         valid_methods = ['meantheta', 'constantq', 'constanttof']
         for method in self.config.method_per_run:
             if method not in valid_methods:
                 raise ValueError(f"Invalid method: {method}. Use one of {valid_methods}")
-        
+
 
         # Set defaults for optional arrays
         if not self.config.ThetaShift:
@@ -85,14 +84,14 @@ class NR_Reduction:
         if not self.config.ScaleFactor:
             self.config.ScaleFactor = [1] * n_settings
         if not self.config.tof_min:
-            self.config.tof_min = [0] * n_settings  
+            self.config.tof_min = [0] * n_settings
         if not self.config.tof_max:
             self.config.tof_max = [100000] * n_settings # TODO: Work out where to set this up properly!
-            
+
     def reduce(self, save=True, save_all=True, plot=True):
         """
         Perform the reduction of all angle settings and combine into an output.
-        
+
         save: (optional) save out the final combined Q, R, dR, dQ file
         save_all: (optiona) save out the combined and individual settings
         plot: (optional) show the NR plot on completion
@@ -103,10 +102,10 @@ class NR_Reduction:
             Dictionary containing Q, R, dR, dQ arrays
         """
         Q, R, dR, dQ = [], [], [], []
-        
+
         # TODO: Add handling for summed run files.
         for i, rb_num in enumerate(self.config.RBnum):
-            print(f'--------------------------------------------')
+            print('--------------------------------------------')
             result = self._reduce_single_run(i, rb_num)
 
             # TODO: add better autoscaling options.
@@ -114,8 +113,8 @@ class NR_Reduction:
                 y1=R[i-1][np.where(Q[i-1] >= min(result['q']))]
                 y2=result['r'][np.where(result['q'] <= max(Q[i-1]))]
                 e1=dR[i-1][np.where(Q[i-1] >= min(result['q']))]
-                e2=result['dr'][np.where(result['q'] <= max(Q[i-1]))]   
-        
+                e2=result['dr'][np.where(result['q'] <= max(Q[i-1]))]
+
                 scale, sigma_scale = tools.weighted_mean(y1,y2,e1,e2)
                 result['r'] = result['r'] * scale
                 result['dr'] = result['dr'] * scale
@@ -130,13 +129,13 @@ class NR_Reduction:
                 # TODO: Need to fix the saving logic for multiple runs!! At the moment the save looks for the capitals...
                 result_out = {'Q': result['q'], 'R': result['r'], 'dR': result['dr'], 'dQ': result['dq']}
                 self.save_results(result_out, sname=f"{self.config.Sname}_{i}", method=self.config.method_per_run[i])
-        
+
         # Combine results for all settings
         Q_combined = np.concatenate(Q)
         R_combined = np.concatenate(R)
         dR_combined = np.concatenate(dR)
         dQ_combined = np.concatenate(dQ)
-        
+
         # Sort by Q for combined data
         idx = np.argsort(Q_combined)
         combine_results = {'Q': Q_combined[idx], 'R': R_combined[idx], 'dR': dR_combined[idx], 'dQ': dQ_combined[idx]}
@@ -146,11 +145,11 @@ class NR_Reduction:
         # TODO: Decide whether to keep in here or have as a separate part after the reduciton....?
         if plot:
             for i, rb_num in enumerate(self.config.RBnum):
-                if self.config.plotQ4: 
+                if self.config.plotQ4:
                     plt.errorbar(Q[i],R[i]*Q[i]**4, yerr=dR[i]*Q[i]**4, xerr=dQ[i],  fmt='o', markersize=1)
                     plt.ylabel(r'$R \cdot Q^4$', fontsize=14)
                     plt.xscale('linear')
-                else: 
+                else:
                     plt.errorbar(Q[i],R[i], yerr=dR[i], xerr=dQ[i],  fmt='o', markersize=1)
                     plt.ylabel('R')
                     plt.xscale('log')
@@ -170,24 +169,24 @@ class NR_Reduction:
             'dR_per_run': dR,
             'dQ_per_run': dQ,
         }
-    
+
     def _load_binary_from_disk(self, rb_num, i):
         """
-        This is not used in the main workflow as want to recalculate based on x-ranges. In future if store binary as 
+        This is not used in the main workflow as want to recalculate based on x-ranges. In future if store binary as
         both x and y this might be useful.
         """
         # Define expected binary file paths
         nRB_bin = self.config.BINpath / f"{rb_num}{self.config.BINsubname}.npy"
         nRBE_bin = self.config.BINpath / f"{rb_num}{self.config.errBINsubname}.npy"
         nRB_tof = self.config.BINpath / f"{rb_num}{self.config.DTCsubname}.dat"
-        
+
         # Check if all binary files exist
         files_exist = (
-            os.path.isfile(nRB_bin) and 
-            os.path.isfile(nRBE_bin) and 
+            os.path.isfile(nRB_bin) and
+            os.path.isfile(nRBE_bin) and
             os.path.isfile(nRB_tof)
         )
-    
+
         if files_exist:
             # Load from cached binary files
             print(f"Loading cached binary files for run {rb_num}")
@@ -197,7 +196,7 @@ class NR_Reduction:
             tof_array = tof_crc[0] if isinstance(tof_crc, np.ndarray) and len(tof_crc.shape) > 1 else tof_crc
             log_values = {} # TODO: Better handling here, possible read of header? For now this is not in the workflow.
             return tof_array, y_tof_corr, error_array_corr, log_values
-        
+
         else:
             # Binary files don't exist, compute from Nexus file
             print(f"Computing binary data from Nexus file for run {rb_num}...")
@@ -207,20 +206,20 @@ class NR_Reduction:
     def _make_binary_files(self, rb_num, tof_min=0, tof_max=50000):
         """
         Make binary files.
-        
+
         If computes from nexus, returns the TOF array, Y vs TOF data, and error array without saving to disk.
         This allows parameters like lowres to be updated without using stale cached files.
-        
+
         Parameters
         ----------
         rb_num : int
             Run block number
-        
+
         Returns
         -------
         tuple
             (tof_array, y_tof_corr, error_array_corr) - Arrays ready for reduction
-        
+
         Raises
         ------
         FileNotFoundError
@@ -228,15 +227,15 @@ class NR_Reduction:
         RuntimeError
             If binary processing fails
         """
-                
+
         # Get Nexus file path
         nNxRB = self.config.NEXUSpathRB / f"REF_L_{rb_num}.nxs.h5"
-        
+
         if not os.path.isfile(nNxRB):
             raise FileNotFoundError(f"Nexus file not found: {nNxRB}")
-        
+
         lowres = self.config.data_x_range
-        
+
         # Convert to binary
         try:
             tof_array, y_tof_corr, error_array_corr, log_values, _ = BP.convert_to_binary(
@@ -251,26 +250,26 @@ class NR_Reduction:
                 n_y=304,    # TODO: Work out how to add here when settings not created yet.
                 n_x=256
             )
-            
+
             print(f"Binary data computed successfully for run {rb_num}")
             return tof_array, y_tof_corr, error_array_corr, log_values
-            
+
         except Exception as e:
             raise RuntimeError(f"Failed to compute binary data for run {rb_num}: {str(e)}")
-    
+
     def _load_and_extract_lambda(self, i, rb_num):
         """
         Load binary TOF data and convert to lambda space including the emission time correction.
         Return arrays for run and direct beam with matching bins.
         Return additional metadata for later calculations.
-        
+
         Parameters
         ----------
         i : int
             Run index
         rb_num : int
             Run number
-            
+
         Returns
         -------
         tuple
@@ -284,8 +283,8 @@ class NR_Reduction:
         settings = tools.read_settings(log_values["start_time"])
         self.settings = self.apply_config_overrides(settings)
         self.settings['si_sample_distance'] = self.settings['xi_reference'] - self.log_values['xi']
-        self.settings['interslit_distance'] = self.settings['s1_sample_distance'] - self.settings['si_sample_distance']    
-        
+        self.settings['interslit_distance'] = self.settings['s1_sample_distance'] - self.settings['si_sample_distance']
+
         # Calculate lam range if not provided - # TODO: Add smarter calculation.
         if self.config.LambdaMin is None or self.config.LambdaMax is None:
             lam_range = tools.get_lam_range(self.log_values["lam_request"], self.log_values["frequency"])
@@ -301,7 +300,7 @@ class NR_Reduction:
         # Flip the arrays to give detector pixel ascending.
         RB = np.flipud(nRB)
         RBE = np.flipud(nRBE)
-        
+
         # Read in pre-processed direct beam file and extract header information from pre-process step.
         lDB, iDB, eDB, metaDB = tools.load_db_file(self.config.DBpath, self.config.DBname[i])
         DBpixel = float(metaDB['db_pixel']) # TODO: Add handling for if this doesn't exist.
@@ -316,7 +315,7 @@ class NR_Reduction:
         ThCen = theta_motor + self.config.ThetaShift[i]
         self.log_values['ThCen'] = ThCen
         print(f"Theta, TTHD = {np.round(ThCen, 3)}, {np.round(self.log_values['tthd'], 3)}")
-        
+
         # Create Q vector
         q = tools.log_qvector(self.config.qmin, self.config.qmax, self.config.dqbin)
         # Y pixel array
@@ -343,30 +342,30 @@ class NR_Reduction:
         LAMBDA = 3956 * (tRB) / self.settings['source_detector_distance']
         LAMBDA = 3956 * (tRB - (t0[0] + t0[1] * LAMBDA)) / self.settings['source_detector_distance']
         LambdaBinSize = abs(LAMBDA[1] - LAMBDA[0])
-        
+
         # Trim to desired lambda range
         mask = ((LAMBDA >= self.config.LambdaMinUse) & (LAMBDA <= self.config.LambdaMaxUse))
         LAMBDA = LAMBDA[mask]
         RB = RB[:, mask]
         RBE = RBE[:, mask]
-        
+
         # # Interpolate DB lambda to match new RB binning
         # iDB = np.interp(LAMBDA, lDB, iDB)
         # eDB = np.interp(LAMBDA, lDB, eDB)
-        
+
         # Rebin DB lambda to match new RB binning
         iDB = tools.rebin_counts(LAMBDA, lDB, iDB)
         eDB = np.sqrt(tools.rebin_counts(LAMBDA, lDB, eDB**2))
-        
+
         # TODO: check what is stored and whether this is the best place.
         self.q = q
-        
+
         return lDB, iDB, eDB, DBpixel, DBtthd, q, ypix, RB, RBE, LAMBDA, LambdaBinSize, ThCen, mode # TODO: should q be returned and a self.q?
 
     def _fit_and_calculate_theta(self, i, ypix, RB, DBpixel, DBtthd, ThCen):
         """
         Fit specular peak position on detector and calculate corresponding theta
-        
+
         Parameters
         ----------
         i : int
@@ -381,7 +380,7 @@ class NR_Reduction:
             Direct beam tthd angle
         ThCen : float
             Theta value from logs (i.e. starting theta)
-            
+
         Returns
         -------
         tuple
@@ -399,7 +398,7 @@ class NR_Reduction:
         par, fit, bkg = tools.fit_peak(Ydata, Idata, peaktype=self.config.peak_type, bkgtype='linear')
         Yfit = fit[:, 0]
         Ifit = fit[:, 1]
-        
+
         # Calculate theta from fit pixel position and comparison to expected peak position based on DB pixel/tthd positions.
         RBpixel = par[1]
         dPix = RBpixel - DBpixel
@@ -413,7 +412,7 @@ class NR_Reduction:
         # TODO: Alter the function to do the calculation once and apply different angle offsets
         # Calculate expected beam profile on detector using logs
         Icalc_nonfit = tools.calc_beam_on_detector(Yfit, DBpixel, self.log_values['siY'], self.log_values['s1Y'],
-                                            self.settings['interslit_distance'], self.settings['si_sample_distance'], 
+                                            self.settings['interslit_distance'], self.settings['si_sample_distance'],
                                          self.settings['sample_detector_distance'], self.settings['pixel_width'],
                                          self.config.DetSigma, self.config.DetResFn)
 
@@ -423,16 +422,16 @@ class NR_Reduction:
             self.log_values['ThCen'] = ThCen
             # Calculate expected beam profile on detector using logs
             Icalc = tools.calc_beam_on_detector(Yfit, RBpixel, self.log_values['siY'], self.log_values['s1Y'],
-                                        self.settings['interslit_distance'], self.settings['si_sample_distance'], 
+                                        self.settings['interslit_distance'], self.settings['si_sample_distance'],
                                         self.settings['sample_detector_distance'], self.settings['pixel_width'],
                                         self.config.DetSigma, self.config.DetResFn)
         else:
             RBpixel = DBpixel
             Icalc = Icalc_nonfit
-        
+
         Icalc = (Icalc * par[0]) + bkg
         Icalc_nonfit = (Icalc_nonfit * par[0]) + bkg
-        
+
         # Plot beam profile if requested - compares to calculated profile from instrument geometry.
         if self.config.plotON:
             fig, ax = plt.subplots()
@@ -450,33 +449,33 @@ class NR_Reduction:
             ax.set_xlabel('Detector Pixel', fontsize=14)
             ax.legend()
             plt.show()
-        
+
         return Yfit, Ifit, RBpixel, Icalc, ThCen, bkg
 
     def _calculate_jacobian(self, LAMBDA, Thv, include_dqdtheta=True):
         """Calculate Jacobian determinant for Q-space transformation.
-        
+
         Args:
             LAMBDA: Wavelength array
             Thv: Theta values (can be 1D or 2D)
             include_dqdtheta: If True, use full 2D Jacobian; if False, use only dqdlambda
-        
+
         Returns:
             J: Jacobian magnitude
         """
         dqdtheta = (4 * np.pi / LAMBDA) * np.cos(np.radians(Thv)) * np.pi / 180
         dqdlambda = -(4 * np.pi / LAMBDA**2) * np.sin(np.radians(Thv))
-        
+
         if include_dqdtheta:
             jacobian = abs(np.sqrt(dqdtheta**2 + dqdlambda**2))
         else:
             jacobian = abs(dqdlambda)
-        
+
         return jacobian
-    
+
     def _pixel_to_q(self, Thv, LAMBDA, LambdaBinSize, dTheta, dLambda, ThetaBinSize=0):
         """Calculate Q values and resolution for a given theta and wavelength.
-        
+
         Args:
             Thv: Theta value
             LAMBDA: Wavelength value
@@ -484,24 +483,24 @@ class NR_Reduction:
             dTheta: Theta sigma values
             dLambda: Wavelength sigma values
             ThetaBinSize: Optional inclusion of theta bin size for non-constantTOF
-        
+
         Returns:
             qcen, qlo, qhi, dq_val
         """
         qcen = 4 * np.pi * np.sin(np.radians(Thv)) / LAMBDA
         qlo = 4 * np.pi * np.sin(np.radians(Thv - ThetaBinSize / 2)) / (LAMBDA + LambdaBinSize / 2)
-        qhi = 4 * np.pi * np.sin(np.radians(Thv + ThetaBinSize / 2)) / (LAMBDA - LambdaBinSize / 2)       
+        qhi = 4 * np.pi * np.sin(np.radians(Thv + ThetaBinSize / 2)) / (LAMBDA - LambdaBinSize / 2)
         dq_val = qcen * np.sqrt((dLambda / LAMBDA)**2 + (dTheta / Thv)**2)
-        
+
         return qcen, qlo, qhi, dq_val
-    
+
     def _calculate_theta_and_bins(self, ymmRB, ThCen, method):
         """Calculate theta mapping based on reduction method (constantQ or meanTheta).
-        
+
         Args:
             ymmRB: Y pixel positions in mm relative to RB center
             ThCen: Center theta angle to be used in calculation
-        
+
         Returns:
             Theta: Theta array for each pixel
             ThetaBinSize: Bin sizes for array
@@ -511,11 +510,11 @@ class NR_Reduction:
         print(method)
         if method == 'meantheta':
             # Calculate mean theta from slits
-            MeanTheta, dTheta = self.calc_mean_theta(ymmRB, self.log_values['s1Y'], self.log_values['siY'], 
+            MeanTheta, dTheta = self.calc_mean_theta(ymmRB, self.log_values['s1Y'], self.log_values['siY'],
                                                     self.settings['sample_detector_distance'], self.settings['si_sample_distance'],
                                                     self.settings['interslit_distance'], self.config.DetSigma,
                                                     self.config.DetResFn, self.config.plotON)
-            
+
             MeanTheta = MeanTheta + ThCen
             Theta = MeanTheta
         elif method == 'constantq':
@@ -529,35 +528,35 @@ class NR_Reduction:
             dTheta = np.full(len(Theta), dTheta_val)
         else:
             raise ValueError("Theta calculation only defined for config.method 'constantQ' or 'meanTheta'")
-            
+
         # Store theta bins for next calculation.
         ThetaBinSize = abs(np.diff(Theta))
         lastBinSize = ThetaBinSize[-1]
         ThetaBinSize = np.concatenate([ThetaBinSize, [lastBinSize]])
-        
+
         return Theta, ThetaBinSize, dTheta
-    
+
     def _calc_detector_convolution(self,m, b, ResFn, sigma, plotON=True):
-        
+
         verts = [
                 tools.intersect(m[0], b[0], m[1], b[1]),
                 tools.intersect(m[1], b[1], m[2], b[2]),
                 tools.intersect(m[2], b[2], m[3], b[3]),
                 tools.intersect(m[3], b[3], m[0], b[0]),
             ]
-            
+
         verts = np.array(verts)
         Det_corners = np.vstack([verts, verts[0]])
-            
+
         #pad the y axis to prepare for convolution
         if ResFn == 'rectangular':
-            pad = sigma * np.sqrt(12) 
+            pad = sigma * np.sqrt(12)
             width = sigma * np.sqrt(12)
 
         if ResFn == 'gaussian':
-            pad = sigma * 4.0 
+            pad = sigma * 4.0
 
-            
+
         # define the theta and Y vectors, Y is padded to allow convolution
         nt=1000
         ny=1000
@@ -568,29 +567,29 @@ class NR_Reduction:
 
         # create a smeared array
         smear=np.zeros((ny,nt))
-            
+
         #loop through theta
         for i in range(nt):
             #calculate the hi and lo Y values in this theta slice
             hi = np.minimum(tvec[i]*m[3] + b[3], tvec[i]*m[2] + b[2])
             lo = np.maximum(tvec[i]*m[0] + b[0], tvec[i]*m[1] + b[1])
-            
+
             # make a tophat function
             p = np.where((yvec >= lo) & (yvec <= hi))
             d = yvec*0
             d[p] = d[p]+1
 
             # smear it and store it
-            if ResFn == 'rectangular': 
-                smear[:,i] = uniform_filter1d(d, size=int(width/ystep)) 
-            if ResFn == 'gaussian': 
-                smear[:,i] = gaussian_filter1d(d, sigma = sigma/ystep)     
-        
+            if ResFn == 'rectangular':
+                smear[:,i] = uniform_filter1d(d, size=int(width/ystep))
+            if ResFn == 'gaussian':
+                smear[:,i] = gaussian_filter1d(d, sigma = sigma/ystep)
+
         # mask out empty rows
         mask = np.any(smear != 0, axis = 1)
         smear = smear[mask]
         yvec = yvec[mask]
-            
+
         if plotON:
             fig, ax = plt.subplots()
             ax.imshow(smear, origin='lower', aspect='auto', extent=[min(tvec),max(tvec),min(yvec),max(yvec)], cmap='magma')
@@ -605,7 +604,7 @@ class NR_Reduction:
         # Calculate the Mean and Sigma of theta angles as a function of Y position on the detector
         # create a fine grid of Y positions, convolve with the detector resolution
         # calculate the mean and sigma for provided Y values from the convolved array
-        
+
         # define positive angles and up and negative angles as down
         a, y, m, b = tools.calc_beam_geometry_from_slits(si_H, s1_H, d_s1_si, d_si_sam, d_sam_det, radians=False)
 
@@ -618,15 +617,15 @@ class NR_Reduction:
 
         for Y in yvalues:
             pos = np.where(abs(Y-yvec) == min(abs(Y-yvec)))
-            
+
             # simple line cut through convolved array
             mu = np.sum(smear[pos,:] * tvec) / np.sum(smear[pos,:])
             var = np.sum(smear[pos,:] * (tvec - mu)**2) / np.sum(smear[pos,:])
             sig = np.sqrt(var)
-            
+
             mean_theta.append(mu)
             sigma_theta.append(sig)
-            
+
         mean_theta = np.array(mean_theta)
         sigma_theta = np.array(sigma_theta)
 
@@ -636,11 +635,11 @@ class NR_Reduction:
     def plot_theta_lam(self, LAMBDA, Theta, Rarr, iDB, qlines=True, set_ylims=None, set_xlims=None): #TODO: decide if this should be in the class?
             '''
             Generate 2D plot of theta-lambda with option to overlay lines of constant q from calculation
-            
+
             LAMBDA: array of lambda values
             Theta: corresponding array of theta values
-            Rarr: 
-            iDB: 
+            Rarr:
+            iDB:
             qlines: Option to overlay q lines
             set_ylims: Option to specify y limits, otherwise uses extent of Theta array. (e.g. [0.3,0.8])
             set_xlims: Option to specify x limits, otherwise uses LambdaMin and LambdaMax from config. (e.g. [2.2, 9])
@@ -652,14 +651,14 @@ class NR_Reduction:
             cmap = 'magma'
             ax.pcolormesh(LAMBDA, abs(Theta), RN, norm=LogNorm(vmin=vmin, vmax=RN.max()),
                           shading='auto', cmap=cmap)
-            
+
             if qlines:
                 dqbin_plot = self.config.dqbin * 20
                 qvs = tools.log_qvector(self.config.qmin, self.config.qmax, dqbin_plot)
                 for qv in qvs:
                     qline = np.degrees(np.arcsin(qv * LAMBDA / 4 / np.pi))
                     ax.plot(LAMBDA, qline, '--g', linewidth=1.5)
-            
+
             if set_ylims:
                 ax.set_ylim(set_ylims[0],set_ylims[1])
             else:
@@ -674,7 +673,7 @@ class NR_Reduction:
             ax.set_xlabel('Lambda [Å]', fontsize=14)
             ax.set_ylabel('Theta [deg]', fontsize=14)
             plt.show()
-    
+
     def _background_roi_sorter(self, BkgROI, ymin, ymax):
         # Wrapper to handle the background region when set by the template.
         # This has 2 zeroes in the array when only 1 background region is selected.
@@ -697,9 +696,9 @@ class NR_Reduction:
         Calculate and apply background subtraction.
         This is handled in lambda space so uses a different function to lr_reduction.
         Background range supplied as a single array of size 4 to be start and stop
-        values either side of the specular peak. There will be a separate helper function 
+        values either side of the specular peak. There will be a separate helper function
         for handling when this is adjacent to the specular (i.e. provides zeros in the template)
-        
+
         LAMBDA: Description
         R: Description
         E: Description
@@ -732,7 +731,7 @@ class NR_Reduction:
 
         # uncertainties
         var_bkg = (eb1**2 + eb2**2) / 2
-        
+
         if ploton:
             self.roi_plot(R, ypix, y_roi, LAMBDA, ymin, ymax, bkgd=True, background_idx=background_idx)
             '''
@@ -747,7 +746,7 @@ class NR_Reduction:
             ax.axhline(y=background_idx[0], color='red', linestyle='--', linewidth=1)
             ax.axhline(y=background_idx[1], color='red', linestyle='--', linewidth=1)
             ax.axhline(y=background_idx[2], color='red', linestyle='--', linewidth=1)
-            ax.axhline(y=background_idx[3], color='red', linestyle='--', linewidth=1) 
+            ax.axhline(y=background_idx[3], color='red', linestyle='--', linewidth=1)
             ax.set_title('Background subtraction ROIs', fontsize=16)
             ax.set_xlabel('Lambda [Å]', fontsize=14)
             ax.set_ylabel('Detector Pixel', fontsize=14)
@@ -757,7 +756,7 @@ class NR_Reduction:
         # subtract background
         for i in range(R.shape[1]):
             bkg = a[i] * y_roi + c[i]
-            
+
             R_crop[:, i] -= bkg
             E_crop[:, i] = np.sqrt(E_crop[:, i]**2 + var_bkg[i])
 
@@ -780,7 +779,7 @@ class NR_Reduction:
             ax.axhline(y=background_idx[0], color='red', linestyle='--', linewidth=1)
             ax.axhline(y=background_idx[1], color='red', linestyle='--', linewidth=1)
             ax.axhline(y=background_idx[2], color='red', linestyle='--', linewidth=1)
-            ax.axhline(y=background_idx[3], color='red', linestyle='--', linewidth=1) 
+            ax.axhline(y=background_idx[3], color='red', linestyle='--', linewidth=1)
         ax.set_title('Y-pixel ROIs', fontsize=16)
         ax.set_xlabel('Lambda [Å]', fontsize=14)
         ax.set_ylabel('Detector Pixel', fontsize=14)
@@ -815,14 +814,14 @@ class NR_Reduction:
     def _reduce_single_run(self, i, rb_num, save=True):
         """
         Reduce a single run setting using the pre-defined config.
-        
+
         Parameters
         ----------
         i : int
             Run index within the set to be combined (e.g. for angle-variable settings)
         rb_num : int
             Run number
-            
+
         Returns
         -------
         dict
@@ -865,11 +864,11 @@ class NR_Reduction:
             # for continuity, probably needs clearing up:
             Rarr = iRB
             REarr = eRB
-        
+
         # Normalize by incident spectrum & propagate error
-        R0 = Rarr.copy()       
+        R0 = Rarr.copy()
         Rarr, REarr = tools.divide_propagate_error(R0, REarr, iDB, eDB)
-        
+
         # Remove NaNs - #TODO: check if this is still correct...
         nan_idx = ~np.isfinite(Rarr)
         Rarr[nan_idx] = 0
@@ -889,13 +888,13 @@ class NR_Reduction:
             # Plot 2D lambda vs theta data including overlay of q-summing lines
             if self.config.plotON:
                 self.plot_theta_lam(LAMBDA, Theta, Rarr, iDB, qlines=True)
-        
+
             # Remove truncated Q-lines based on qline threshold
             lmin = 4 * np.pi * np.sin(np.radians(min(abs(Theta)))) / self.q #TODO: track through self.q vs qvals...!!
             lmax = 4 * np.pi * np.sin(np.radians(max(abs(Theta)))) / self.q
-            Qline_fraction = (np.minimum(self.config.LambdaMaxUse, lmax) - 
+            Qline_fraction = (np.minimum(self.config.LambdaMaxUse, lmax) -
                             np.maximum(self.config.LambdaMinUse, lmin)) / (lmax - lmin)
-        
+
             mask = (Qline_fraction >= self.config.Qline_threshold)
             q_vals = self.q[mask]
             Qline_fraction = Qline_fraction[mask]
@@ -913,10 +912,10 @@ class NR_Reduction:
             dTheta = np.array([tools.dTheta_Sigma(self.log_values['siY'], self.log_values['s1Y'], self.settings['interslit_distance'])])
             q_vals = self.q
             Qline_fraction = np.ones(len(q_vals)) # check this!!
-        
+
         # Lambda resolution
         dLambda = tools.dLambda_Sigma(LAMBDA)
-        
+
         # Gravity correction
         # For this function expects e.g. 4.0 for downward angle
         if mode == 1:
@@ -924,7 +923,7 @@ class NR_Reduction:
         else:
             IncTheta = self.log_values["thi"]
         ThetaGC = tools.gravity_correct(LAMBDA, IncTheta, self.settings['si_sample_distance'], self.settings['interslit_distance'])
-        
+
         # Transform to Q-space
         ## something is wrong with q_vals shape. Might need to reassign self.q to q_vals...?
         #r = self.q * 0
@@ -953,7 +952,7 @@ class NR_Reduction:
                 # Jacobian determinant
                 J = self._calculate_jacobian(LAMBDA, Thv, include_dqdtheta=True)
                 theta_bin = ThetaBinSize[T]
-            
+
             # Loop through lambda to map to Q space
             for L in range(Rarr.shape[1]):
                 # Calculate Q values
@@ -975,14 +974,14 @@ class NR_Reduction:
                     Jsum[idx] = Jsum[idx] + wt
 
         FAC = Jsum / Rarr.shape[0]
-        
+
         # Remove NaNs and zeros and keep region within qline fraction #TODO: work out whether the qline_fraction part is needed both here and above.
         mask = (np.isfinite(r) & (FAC != 0))
         q_vals, r, dr, dq, FAC, Qline_fraction = (x[mask] for x in (q_vals, r, dr, dq, FAC, Qline_fraction))
-        
+
         r = r / FAC * Qline_fraction
         dr = np.sqrt(dr) / FAC * Qline_fraction
-        
+
         # Apply scale factor if specified.
         r = r * self.config.ScaleFactor[i]
         dr = dr * self.config.ScaleFactor[i]
@@ -999,14 +998,14 @@ class NR_Reduction:
     def save_results(self, results, sname = None, full=True, method=None):
         """
         Save results as .dat file with header
-        
+
         Parameters
         ----------
         results : dict
             Results from reduce() method
         """
         array = np.column_stack((results['Q'], results['R'], results['dR'], results['dQ']))
-        
+
         # TODO: Sort out the header to include best information...
         if full:
             head = (
@@ -1045,12 +1044,12 @@ class NR_Reduction:
         np.savetxt(output_file,
                   array, header=head, delimiter='\t')
         print(f"Saved combined result to {output_file}")
-    
+
     def apply_config_overrides(self, settings: dict) -> dict:
         """
         Apply overrides to the instrument settings if not None in the config
         and returns updated dictionary.
-        
+
         """
         overrides = {
             'xi_reference': getattr(self.config, 'xi_ref', None),

--- a/src/lr_reduction/nr_reduction_config.py
+++ b/src/lr_reduction/nr_reduction_config.py
@@ -1,18 +1,19 @@
 from pathlib import Path
 
+
 class NRReductionConfig:
     """
     Configuration class for NR reduction parameters.
     This defines setable parameters for the workflow including defaults for when they are not provided.
     These can be read and set from a template file.
     """
-    
+
     def __init__(self):
         """
         Initialize reduction configuration.
         Method allows different conversion routes from lambda to q to be selected based on the experimental setup.
         It will allow expansion to other methods as developments occur.
-        
+
         Parameters
         ----------
         method : str
@@ -21,7 +22,7 @@ class NRReductionConfig:
         #self.method = method.lower()
         #if self.method not in ['constantq', 'meantheta', 'constanttof']:
         #    raise ValueError(f"Unknown method: {method}. Use 'constantQ', 'meanTheta', or 'constantTOF'")
-        
+
         # Allow for per run setting of the method
         self.method_per_run = []  # This should be an array of the same length as the data arrays with the method for each run. If empty, will use the default method for all runs.
 
@@ -49,20 +50,20 @@ class NRReductionConfig:
         self.useCalcTheta = False   # Toggle to use a fitted specular peak position (relative to the DB position) for theta which overwrites the THS/THI values
         self.plotON = True  # Toggle for plots to show during the reduction steps. Turn off for batch processing etc.
         self.plotQ4 = False # Toggle for the NR plots to be RQ4 vs RQ.
-        
+
         # Background configuration
         self.BkgROI = []    # Need to work out a default...and explain the format here.
         self.useBS = []  # Toggle to use background subtraction per angle
-        self.useGravity = True # Toggle to use gravity correction 
+        self.useGravity = True # Toggle to use gravity correction
         # TODO: After testing, decide how/if to toggle gravity and if it should be in the template.
-        
+
         # Q-space configuration #TODO: make better defaults here!!
         # These should be specified within the templates but enable ranges for lambda and q. #TODO: check if zeros are removed?
         self.qmin = 0.001
         self.qmax = 0.5
         self.dqbin = 0.005
         self.Qline_threshold = 1.0  # Fraction of q-line required to be within the bin to be included in the non-constantTOF mode.
-        
+
         self.LambdaMin = None    #If None this will be calculated from the chopper ranges. If supplied should be an array.
         self.LambdaMax = None
         self.tof_max = [] # Need a better way to autoset this...
@@ -73,7 +74,7 @@ class NRReductionConfig:
         self.ThetaShift = []  # Per-angle theta shift in degrees
         self.ScaleFactor = []  # Per-angle scale factor
         self.Qnorm = 0.015  # Q threshold for normalization
-        
+
         # Instrument geometry - generally read from the instrument settings (if None) but can be overwritten.
         self.mmpix = None  # pixel size in mm
         self.dSampDet = None # sample-to-detector distance
@@ -86,7 +87,7 @@ class NRReductionConfig:
         self.IncidentTheta = 4.0  # degrees Angle of the beamline relative to earth. Positive is downwards. Will become PV.
         self.emission_coefficients = None  # TOF emission time coefficients
         self.use_emission_time = True # Toggles application of the emission time correction and which distance is to be used.
- 
+
         # Dead-time parameters
         self.dead_time = 4.2
         self.dead_time_tof_step = 50
@@ -101,11 +102,11 @@ class NRReductionConfig:
         self.peak_type = 'supergauss'   # function for the fit. Current options: 'gauss' or 'supergauss'
 
     # Path configuration - Defaults assume IPTS specified and saved into that folder.
-    # #TODO: test the defaults loading part...!        
+    # #TODO: test the defaults loading part...!
     @property
     def base_path(self) -> Path:
         return Path("/SNS/REF_L") / self.experiment_id
-    
+
     @property
     def Spath(self) -> Path:
         if self._Spath_override is not None:

--- a/src/lr_reduction/nr_tools.py
+++ b/src/lr_reduction/nr_tools.py
@@ -3,20 +3,22 @@ Subset of functions which may be useful outside of the NRReduction calculation c
 # TODO: Lots of this files still needs commenting.
 """
 
-import numpy as np
-from scipy.optimize import curve_fit
-from pathlib import Path
 import datetime
 import json
 import os
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import curve_fit
+
 
 def safe_divide(numerator, denominator):
     """Wrapper for safe division with zeros where denominator is zero.
-    
+
     Args:
         numerator: Numerator array
         denominator: Denominator array
-    
+
     Returns:
         Result array with zeros where denominator is zero
     """
@@ -24,33 +26,33 @@ def safe_divide(numerator, denominator):
 
 def divide_propagate_error(num, num_err, denom, denom_err):
     """Wrapper to proagate errors through division consistently: (num/denom).
-    
+
     Args:
         num: Numerator array
         num_err: Numerator error array
         denom: Denominator array
         denom_err: Denominator error array
-    
+
     Returns:
         (result, error): Divided array and propagated error
     """
     result = safe_divide(num, denom)
-    
+
     # Error propagation: (num/denom) has error sqrt((num_err/num)^2 + (denom_err/denom)^2) * (num/denom)
     term1 = safe_divide(num_err, num)
     term2 = safe_divide(denom_err, denom)
     error = np.abs(result) * np.sqrt(term1**2 + term2**2)
-    
+
     return result, error
 
 def find_pixel_index(pixels, value, occurence=0):
     """Wrapper to find specific pixel index
-    
+
     Args:
         pixels: Pixel array
         value: Value to find
         occurence: specific occurence or all (e.g. first, last). Use None for full array. default is first.
-    
+
     Returns:
         Index depending on occurrence
     """
@@ -62,7 +64,7 @@ def find_pixel_index(pixels, value, occurence=0):
 def log_qvector(qmin, qmax, dqbin):
     """
     Generate logarithmically spaced q vector of defined bin size.
-    
+
     qmin: minimum q
     qmax: maximum q
     dqbin: bin size
@@ -70,7 +72,7 @@ def log_qvector(qmin, qmax, dqbin):
     n = int(np.floor(np.log(qmax/qmin) / np.log(1 + dqbin))) + 1
     return qmin * (1 + dqbin) ** np.arange(n + 1)
 
-def weighted_mean(y1,y2,e1,e2, sigma_mask=3):       
+def weighted_mean(y1,y2,e1,e2, sigma_mask=3):
     #find the weighted average
     v=y1/y2
     sigma_v = np.sqrt((e1 / y2)**2 + (e2 * y1 / y2**2)**2)
@@ -87,7 +89,7 @@ def weighted_mean(y1,y2,e1,e2, sigma_mask=3):
     mean = np.sum(v * w) / np.sum(w)
     sigma_mean = np.sqrt(1 / np.sum(w))
 
-    return mean, sigma_mean 
+    return mean, sigma_mean
 
 # Define functions for peak_fitting:
 def gaussian(x,a,x0,sig):
@@ -110,12 +112,12 @@ def super_gaussian_constant(x, a, x0, sig, ex, c):
 
 def fit_peak(ypix, iY, peaktype="gauss", bkgtype="none"):
     """
-    Fit a peak using a gaussian or super-gauss 
+    Fit a peak using a gaussian or super-gauss
     Returns
     -------
     par : Fit parameters
     fit : y and fitted curve
-    bkg : Background from fit 
+    bkg : Background from fit
     """
     # TODO: can add check on goodness of fit later.
 
@@ -183,7 +185,7 @@ def get_edges(centers):
         e0 = centers[0] - (midpoints[0] - centers[0])
         en = centers[-1] + (centers[-1] - midpoints[-1])
         return np.concatenate(([e0], midpoints, [en]))
-    
+
 def rebin_counts(x, xp, fp):
     """
     Count-preserving rebin from original bin centers (xp)
@@ -207,9 +209,9 @@ def rebin_counts(x, xp, fp):
         xp_edges,
         cumulative,
         left=0.0,
-        right=cumulative[-1]     
+        right=cumulative[-1]
     )
-    
+
     new_counts = np.diff(cumulative_new)
 
     return new_counts
@@ -221,9 +223,9 @@ def calc_beam_geometry_from_slits(si_H, s1_H, d_s1_si, d_si_sam, d_sam_det, radi
 
     # define positive angles and up and negative angles as down
     # a1, a4 are the max and min angle passing through the top of the slit
-    # a2, a3 are the max and min angles passing through the bottom of the slit 
+    # a2, a3 are the max and min angles passing through the bottom of the slit
     # Defined here as a=[a1, a2, a3, a4]
-    
+
     # angular ranges at the incident slits
     a_plus  = np.arctan((s1_H + si_H)/(2*d_s1_si))
     a_minus = np.arctan((s1_H - si_H)/(2*d_s1_si))
@@ -255,8 +257,8 @@ def calc_beam_geometry_from_slits(si_H, s1_H, d_s1_si, d_si_sam, d_sam_det, radi
 def calc_beam_on_detector(Ypix, CenPix, Si, S1, dS1Si, dSiSam, dSamDet, mmpix, DetRes, DetResFn):
     # based on slits and instrument geometry, calculate beam profile on the detector
     # read in the Ypix array to calculate over
-    # adjust by the center pixel 
-    
+    # adjust by the center pixel
+
     Ymm = (Ypix-CenPix) * mmpix
 
     _, y, m, b = calc_beam_geometry_from_slits(Si, S1, dS1Si, dSiSam, dSamDet)
@@ -272,21 +274,21 @@ def calc_beam_on_detector(Ypix, CenPix, Si, S1, dS1Si, dSiSam, dSamDet, mmpix, D
                     (Ymm - b[1]) / m[1])
 
     I = fs - ss
-    
+
     # remove points below y3 and above y1, limits of the polygon
     I[(Ymm < y.min()) | (Ymm > y.max())] = 0
     I[I < 0] = 0
-    
+
     # grid spacing
     dy = Ymm[1] - Ymm[0]
-    
+
     # Convolve with the detector resolution, works better as tophat than gauss!
     if DetResFn == 'rectangular':
         width = DetRes * np.sqrt(12)
         n = max(1, int(np.round(width / dy)))
         kernel = np.ones(n) / n
         I = np.convolve(I, kernel, mode="same")
-        
+
     # Gaussian kernel half-width (~±4σ)
     elif DetResFn == 'gaussian':
         half_width = int(np.ceil(4 * DetRes / dy))
@@ -294,17 +296,17 @@ def calc_beam_on_detector(Ypix, CenPix, Si, S1, dS1Si, dSiSam, dSamDet, mmpix, D
         kernel = np.exp(-0.5 * (xk / DetRes)**2)
         kernel /= kernel.sum()
         I = np.convolve(I, kernel, mode="same")
-    
+
     elif DetResFn not in ["none", None]:
          raise ValueError("DetResFn must be 'rectangular', 'gaussian', or 'none'")
-    
+
     # normalize
     if I.max() <= 0:
         raise ValueError("Maximum I has calculated negative")
     else:
         I = I/I.max()
         return I
-    
+
 def intersect(m1, b1, m2, b2):
     # find intersection of two lines
     x = (b2 - b1) / (m1 - m2)
@@ -313,19 +315,19 @@ def intersect(m1, b1, m2, b2):
 
 # TODO: Link these resolution functions to the lr_reduction ones...
 def dTheta_Sigma(Si, S1, dS1Si):
-    
+
     # Trapezoidal half-width angles (deg)
     HW_bot = np.degrees(np.arctan((S1 + Si) / (2 * dS1Si)))     # full half-width
     HW_top = np.degrees(np.arctan((S1 - Si) / (2 * dS1Si)))     # flat-top half-width
-    
+
     a=-HW_bot
     b=-HW_top
     c=HW_top
     d=HW_bot
-    
+
     #analytical equation for the sigma of a trapezoidal function
     Sigma=np.sqrt(((d-a)**2+(c-b)**2+(d-a)*(c-b))/24)
-     
+
     return Sigma
 
 def dLambda_Sigma(Lambda):
@@ -333,45 +335,45 @@ def dLambda_Sigma(Lambda):
     L = 0.07564423
     A = 0.13093263
     k = 0.34918918
-    
+
     dLAM = L - A*np.exp(-k*Lambda)
 
     return dLAM
 
 # TODO: Link this into the gravity_correction in lr_reduction...
 def gravity_correct(LAM, ThetaIn, dSamp, dSlit):
-    
+
     dSamp=dSamp/1000    #dSamp is m from sample to incident slit
     dSlit=dSlit/1000    #dSlit is m between slits
-    
+
     #calculation from the ILL paper. this works for inclined beams.
     g=9.8067                #m/s^2
     h=6.6260715e-34         #Js=kg m^2/s
     mn=1.67492749804e-27    #kg
     V=h/(mn*LAM*1e-10)
     K=g/(2*V**2)
-       
+
     #define the sample position as x=0, y=0. increasing x is towards moderator
     xs=0
-    
+
     #positions of slits
     x1=dSamp
     x2=(dSamp+dSlit)
-    
+
     #height of slits determined by incident theta, y=0 is the sample height
     y1=x1*np.tan(ThetaIn*np.pi/180)
     y2=x2*np.tan(ThetaIn*np.pi/180)
-    
+
     #this is the location of the top of the parabola
     x0=(y1-y2+K*(x1**2-x2**2))/(2*K*(x1-x2))
     y0=y2+K*(x2-x0)**2
-    
+
     xs=x0-np.sqrt(y0/K)
-    
+
     ThetaSam=np.arctan(2*K*(x0-xs))*180/np.pi                 #angle is arctan(dy/dx) at sample
-    
+
     dTheta=ThetaSam-ThetaIn
-    
+
     return dTheta
 
 


### PR DESCRIPTION
This is a hotfix to deal with incorrect scaling of SlitScan method of direct beams. The ScaleMultiplier needs to be applied to the output intensity and error bar computations. This needs to be extracted from the DASLogs in binary_processing.py.

This code was proven with:
<img width="1014" height="653" alt="Screenshot 2026-04-15 at 6 04 06 PM" src="https://github.com/user-attachments/assets/28b11654-93b3-4f61-9718-c184d814bd40" />
