### PR TITLE
Correction to theta selection depending on run mode

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,7 +33,13 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
           manifest-path: pyproject.toml
-
+          
+      - name: Configure Git credentials for code.ornl.gov
+        env:
+          TOKEN: ${{ secrets.DATA_READ_TOKEN }}
+        run: |
+          git config --global url."https://gitlab-ci-token:${TOKEN}@code.ornl.gov/".insteadOf "https://code.ornl.gov/"
+          
       - name: Download test data
         run: |
           git submodule update --init

--- a/src/lr_reduction/data_info.py
+++ b/src/lr_reduction/data_info.py
@@ -8,6 +8,7 @@ import numpy as np
 from mantid.simpleapi import logger
 
 from lr_reduction.mantid_utils import SampleLogValues
+from lr_reduction.theta_selection import theta_log_name
 from lr_reduction.types import MantidWorkspace
 
 
@@ -38,12 +39,7 @@ class DataType(IntEnum):
         value = cls.REFLECTED_BEAM
         try:
             # Determine whether this is a direct beam based on the geometry
-            if (
-                    # This is a new log for earth-centered
-                    ("BL4B:CS:Mode:Coordinates" in sample_logs and sample_logs["BL4B:CS:Mode:Coordinates"] == 0)
-                    or
-                    # This is for backward compatibility from before the new log value
-                    sample_logs["BL4B:CS:ExpPl:OperatingMode"] == "Free Liquid"):
+            if theta_log_name(sample_logs) == "thi":
                 # Earth-centered coordinate system
                 thi = sample_logs["thi"]
                 tthd = sample_logs["tthd"]

--- a/src/lr_reduction/data_info.py
+++ b/src/lr_reduction/data_info.py
@@ -8,7 +8,7 @@ import numpy as np
 from mantid.simpleapi import logger
 
 from lr_reduction.mantid_utils import SampleLogValues
-from lr_reduction.theta_selection import theta_log_name
+from lr_reduction.theta_selection import is_earth_centered_geometry
 from lr_reduction.types import MantidWorkspace
 
 
@@ -39,7 +39,7 @@ class DataType(IntEnum):
         value = cls.REFLECTED_BEAM
         try:
             # Determine whether this is a direct beam based on the geometry
-            if theta_log_name(sample_logs) == "thi":
+            if is_earth_centered_geometry(sample_logs):
                 # Earth-centered coordinate system
                 thi = sample_logs["thi"]
                 tthd = sample_logs["tthd"]

--- a/src/lr_reduction/data_info.py
+++ b/src/lr_reduction/data_info.py
@@ -39,7 +39,7 @@ class DataType(IntEnum):
         value = cls.REFLECTED_BEAM
         try:
             # Determine whether this is a direct beam based on the geometry
-            if is_earth_centered_geometry(sample_logs):
+            if is_earth_centered_geometry(input_workspace):
                 # Earth-centered coordinate system
                 thi = sample_logs["thi"]
                 tthd = sample_logs["tthd"]

--- a/src/lr_reduction/gravity_correction.py
+++ b/src/lr_reduction/gravity_correction.py
@@ -2,6 +2,7 @@ from enum import IntEnum
 
 import numpy as np
 
+from lr_reduction.theta_selection import uses_incident_theta
 from lr_reduction.types import MantidWorkspace
 from lr_reduction.utils import workspace_handle
 
@@ -95,12 +96,7 @@ def _theta_in(workspace: MantidWorkspace) -> float:
 
     # Angle calculated from thi and a flag on earth-centered vs beam-centered
     thi = _log_value(run, "BL4B:Mot:thi.RBV")
-    if "BL4B:CS:Mode:Coordinates" in run:
-        if _log_value(run, "BL4B:CS:Mode:Coordinates") == 0:  # Earth-centered=0
-            theta_in = thi
-        else:
-            theta_in = thi - 4.0  # Beamline optics gives -4 deg incline. In future will have PV.
-    elif _log_value(run, "BL4B:CS:ExpPl:OperatingMode", default="") == "Free Liquid":
+    if uses_incident_theta(run):
         theta_in = thi
     else:
         theta_in = thi - 4.0

--- a/src/lr_reduction/gravity_correction.py
+++ b/src/lr_reduction/gravity_correction.py
@@ -2,7 +2,7 @@ from enum import IntEnum
 
 import numpy as np
 
-from lr_reduction.theta_selection import uses_incident_theta
+from lr_reduction.theta_selection import is_earth_centered_geometry
 from lr_reduction.types import MantidWorkspace
 from lr_reduction.utils import workspace_handle
 
@@ -92,13 +92,13 @@ def _theta_in(workspace: MantidWorkspace) -> float:
         The calculated incident angle (theta_in) in degrees.
     """
     ws = workspace_handle(workspace)
-    run = ws.getRun()
-
     # Angle calculated from thi and a flag on earth-centered vs beam-centered
+    run = ws.getRun()
     thi = _log_value(run, "BL4B:Mot:thi.RBV")
-    if uses_incident_theta(run):
+    if is_earth_centered_geometry(ws):
         theta_in = thi
     else:
+        # Beamline optics gives -4 deg incline. In future will have PV
         theta_in = thi - 4.0
     return abs(theta_in)
 

--- a/src/lr_reduction/template.py
+++ b/src/lr_reduction/template.py
@@ -13,6 +13,7 @@ from mantid.simpleapi import logger
 from lr_reduction import event_reduction, peak_finding, reduction_template_reader
 from lr_reduction.instrument_settings import InstrumentSettings
 from lr_reduction.reduction_template_reader import ReductionParameters
+from lr_reduction.theta_selection import theta_log_name
 from lr_reduction.types import MantidWorkspace
 
 TOLERANCE = 0.07
@@ -261,22 +262,18 @@ def process_from_template_ws(
     # Determine scattering angle. If a value was given, don't add the offset
     if theta_value is not None:
         theta = theta_value * np.pi / 180.0
+        theta_pv = "input"
     else:
-        if (
-            "BL4B:CS:ExpPl:OperatingMode" in ws_sc.getRun()
-            and ws_sc.getRun().getProperty("BL4B:CS:ExpPl:OperatingMode").value[0] == "Free Liquid"
-        ):
-            theta = thi_value * np.pi / 180.0
-        else:
-            theta = ths_value * np.pi / 180.0
+        theta_pv = theta_log_name(ws_sc.getRun())
+        theta = (thi_value if theta_pv == "thi" else ths_value) * np.pi / 180.0
 
         # Add offset
         theta += template_data.angle_offset * np.pi / 180.0
 
     theta_degrees = theta * 180 / np.pi
     logger.notice(
-        "wl=%g; ths=%g; thi=%g; offset=%g; theta used=%g"
-        % (_wl, ths_value, thi_value, template_data.angle_offset, theta_degrees)
+        "wl=%g; ths=%g; thi=%g; theta_pv=%s; offset=%g; theta used=%g"
+        % (_wl, ths_value, thi_value, theta_pv, template_data.angle_offset, theta_degrees)
     )
 
     # Get the reduction parameters from the template

--- a/src/lr_reduction/template.py
+++ b/src/lr_reduction/template.py
@@ -13,7 +13,7 @@ from mantid.simpleapi import logger
 from lr_reduction import event_reduction, peak_finding, reduction_template_reader
 from lr_reduction.instrument_settings import InstrumentSettings
 from lr_reduction.reduction_template_reader import ReductionParameters
-from lr_reduction.theta_selection import theta_log_name
+from lr_reduction.theta_selection import is_earth_centered_geometry, theta_log_name
 from lr_reduction.types import MantidWorkspace
 
 TOLERANCE = 0.07
@@ -264,8 +264,9 @@ def process_from_template_ws(
         theta = theta_value * np.pi / 180.0
         theta_pv = "input"
     else:
-        theta_pv = theta_log_name(ws_sc.getRun())
-        theta = (thi_value if theta_pv == "thi" else ths_value) * np.pi / 180.0
+        use_incident_theta = is_earth_centered_geometry(ws_sc)
+        theta_pv = theta_log_name(ws_sc)
+        theta = (thi_value if use_incident_theta else ths_value) * np.pi / 180.0
 
         # Add offset
         theta += template_data.angle_offset * np.pi / 180.0

--- a/src/lr_reduction/template.py
+++ b/src/lr_reduction/template.py
@@ -264,9 +264,8 @@ def process_from_template_ws(
         theta = theta_value * np.pi / 180.0
         theta_pv = "input"
     else:
-        use_incident_theta = is_earth_centered_geometry(ws_sc)
         theta_pv = theta_log_name(ws_sc)
-        theta = (thi_value if use_incident_theta else ths_value) * np.pi / 180.0
+        theta = (thi_value if is_earth_centered_geometry(ws_sc) else ths_value) * np.pi / 180.0
 
         # Add offset
         theta += template_data.angle_offset * np.pi / 180.0

--- a/src/lr_reduction/theta_selection.py
+++ b/src/lr_reduction/theta_selection.py
@@ -1,0 +1,48 @@
+"""
+Shared theta log selection rules for Liquids Reflectometer reduction.
+"""
+
+_MISSING = object()
+
+
+def _has_log(log_source, log_name: str) -> bool:
+    return log_name in log_source
+
+
+def _read_log(log_source, log_name: str, default=_MISSING):
+    """
+    Read a sample log value from either a Mantid run object or a mapping-like log source.
+    """
+    if hasattr(log_source, "getProperty"):
+        if log_name in log_source:
+            prop = log_source.getProperty(log_name)
+            if hasattr(prop, "size"):
+                return prop.value[-1]
+            return prop.value
+    elif log_name in log_source:
+        return log_source[log_name]
+
+    if default is not _MISSING:
+        return default
+    raise KeyError(log_name)
+
+
+def uses_incident_theta(log_source) -> bool:
+    """
+    Return True when theta should be derived from `thi` instead of `ths`.
+    """
+    if _has_log(log_source, "BL4B:CS:Mode:Coordinates"):
+        coordinates_mode = _read_log(log_source, "BL4B:CS:Mode:Coordinates")
+        try:
+            return int(coordinates_mode) == 0
+        except (TypeError, ValueError):
+            return False
+
+    return _read_log(log_source, "BL4B:CS:ExpPl:OperatingMode", default="") == "Free Liquid"
+
+
+def theta_log_name(log_source) -> str:
+    """
+    Return the sample log name that should be used for theta.
+    """
+    return "thi" if uses_incident_theta(log_source) else "ths"

--- a/src/lr_reduction/theta_selection.py
+++ b/src/lr_reduction/theta_selection.py
@@ -16,13 +16,13 @@ class SampleLogSource(Protocol):
     def __getitem__(self, log_name: str) -> Any: ...
 
 
-def _sample_logs(log_source: MantidWorkspace | SampleLogSource) -> SampleLogSource:
+def _sample_logs(log_source: MantidWorkspace) -> SampleLogSource:
     """
     Normalize workspace and mapping inputs to a value-based sample-log accessor.
 
     Parameters
     ----------
-    log_source : MantidWorkspace | SampleLogSource
+    log_source : MantidWorkspace
         Workspace or mapping-like object containing sample log values.
 
     Returns
@@ -35,7 +35,7 @@ def _sample_logs(log_source: MantidWorkspace | SampleLogSource) -> SampleLogSour
     return log_source
 
 
-def is_earth_centered_geometry(log_source: MantidWorkspace | SampleLogSource) -> bool:
+def is_earth_centered_geometry(log_source: MantidWorkspace) -> bool:
     """
     Determine whether the run used earth-centered geometry.
 

--- a/src/lr_reduction/theta_selection.py
+++ b/src/lr_reduction/theta_selection.py
@@ -43,7 +43,7 @@ def theta_log_name(log_source: MantidWorkspace) -> str:
     Parameters
     ----------
     log_source : MantidWorkspace
-        Workspace or mapping-like object containing the relevant sample log values.
+        Workspace containing the relevant sample log values.
 
     Returns
     -------

--- a/src/lr_reduction/theta_selection.py
+++ b/src/lr_reduction/theta_selection.py
@@ -2,47 +2,80 @@
 Shared theta log selection rules for Liquids Reflectometer reduction.
 """
 
-_MISSING = object()
+from typing import Any, Protocol
+
+from lr_reduction.mantid_utils import SampleLogValues
+from lr_reduction.types import MantidWorkspace
 
 
-def _has_log(log_source, log_name: str) -> bool:
-    return log_name in log_source
+class SampleLogSource(Protocol):
+    """Value-oriented sample log accessor."""
+
+    def __contains__(self, log_name: str) -> bool: ...
+
+    def __getitem__(self, log_name: str) -> Any: ...
 
 
-def _read_log(log_source, log_name: str, default=_MISSING):
+def _sample_logs(log_source: MantidWorkspace | SampleLogSource) -> SampleLogSource:
     """
-    Read a sample log value from either a Mantid run object or a mapping-like log source.
-    """
-    if hasattr(log_source, "getProperty"):
-        if log_name in log_source:
-            prop = log_source.getProperty(log_name)
-            if hasattr(prop, "size"):
-                return prop.value[-1]
-            return prop.value
-    elif log_name in log_source:
-        return log_source[log_name]
+    Normalize workspace and mapping inputs to a value-based sample-log accessor.
 
-    if default is not _MISSING:
-        return default
-    raise KeyError(log_name)
+    Parameters
+    ----------
+    log_source : MantidWorkspace | SampleLogSource
+        Workspace or mapping-like object containing sample log values.
+
+    Returns
+    -------
+    SampleLogSource
+        Sample-log accessor that returns values instead of Mantid property objects.
+    """
+    if hasattr(log_source, "getRun") or isinstance(log_source, str):
+        return SampleLogValues(log_source)
+    return log_source
 
 
-def uses_incident_theta(log_source) -> bool:
+def is_earth_centered_geometry(log_source: MantidWorkspace | SampleLogSource) -> bool:
     """
-    Return True when theta should be derived from `thi` instead of `ths`.
+    Determine whether the run used earth-centered geometry.
+
+    Parameters
+    ----------
+    log_source : MantidWorkspace | SampleLogSource
+        Workspace or mapping-like object containing the coordinate-mode and
+        operating-mode logs used to determine the beamline geometry.
+
+    Returns
+    -------
+    bool
+        True for earth-centered geometry, False for beam-centered geometry.
+        When the coordinate-mode log is unavailable, falls back to the legacy
+        operating-mode log and treats ``"Free Liquid"`` as earth-centered.
     """
-    if _has_log(log_source, "BL4B:CS:Mode:Coordinates"):
-        coordinates_mode = _read_log(log_source, "BL4B:CS:Mode:Coordinates")
+    sample_logs = _sample_logs(log_source)
+
+    if "BL4B:CS:Mode:Coordinates" in sample_logs:
+        coordinates_mode = sample_logs["BL4B:CS:Mode:Coordinates"]
         try:
             return int(coordinates_mode) == 0
         except (TypeError, ValueError):
             return False
 
-    return _read_log(log_source, "BL4B:CS:ExpPl:OperatingMode", default="") == "Free Liquid"
+    return "BL4B:CS:ExpPl:OperatingMode" in sample_logs and sample_logs["BL4B:CS:ExpPl:OperatingMode"] == "Free Liquid"
 
 
-def theta_log_name(log_source) -> str:
+def theta_log_name(log_source: MantidWorkspace | SampleLogSource) -> str:
     """
     Return the sample log name that should be used for theta.
+
+    Parameters
+    ----------
+    log_source : MantidWorkspace | SampleLogSource
+        Workspace or mapping-like object containing the relevant sample log values.
+
+    Returns
+    -------
+    str
+        ``"thi"`` for earth-centered geometry and ``"ths"`` otherwise.
     """
-    return "thi" if uses_incident_theta(log_source) else "ths"
+    return "thi" if is_earth_centered_geometry(log_source) else "ths"

--- a/src/lr_reduction/theta_selection.py
+++ b/src/lr_reduction/theta_selection.py
@@ -2,37 +2,9 @@
 Shared theta log selection rules for Liquids Reflectometer reduction.
 """
 
-from typing import Any, Protocol
 
 from lr_reduction.mantid_utils import SampleLogValues
 from lr_reduction.types import MantidWorkspace
-
-
-class SampleLogSource(Protocol):
-    """Value-oriented sample log accessor."""
-
-    def __contains__(self, log_name: str) -> bool: ...
-
-    def __getitem__(self, log_name: str) -> Any: ...
-
-
-def _sample_logs(log_source: MantidWorkspace) -> SampleLogSource:
-    """
-    Normalize workspace and mapping inputs to a value-based sample-log accessor.
-
-    Parameters
-    ----------
-    log_source : MantidWorkspace
-        Workspace or mapping-like object containing sample log values.
-
-    Returns
-    -------
-    SampleLogSource
-        Sample-log accessor that returns values instead of Mantid property objects.
-    """
-    if hasattr(log_source, "getRun") or isinstance(log_source, str):
-        return SampleLogValues(log_source)
-    return log_source
 
 
 def is_earth_centered_geometry(log_source: MantidWorkspace) -> bool:
@@ -41,8 +13,8 @@ def is_earth_centered_geometry(log_source: MantidWorkspace) -> bool:
 
     Parameters
     ----------
-    log_source : MantidWorkspace | SampleLogSource
-        Workspace or mapping-like object containing the coordinate-mode and
+    log_source : MantidWorkspace
+        Workspace containing the coordinate-mode and
         operating-mode logs used to determine the beamline geometry.
 
     Returns
@@ -52,7 +24,7 @@ def is_earth_centered_geometry(log_source: MantidWorkspace) -> bool:
         When the coordinate-mode log is unavailable, falls back to the legacy
         operating-mode log and treats ``"Free Liquid"`` as earth-centered.
     """
-    sample_logs = _sample_logs(log_source)
+    sample_logs = SampleLogValues(log_source)
 
     if "BL4B:CS:Mode:Coordinates" in sample_logs:
         coordinates_mode = sample_logs["BL4B:CS:Mode:Coordinates"]
@@ -64,13 +36,13 @@ def is_earth_centered_geometry(log_source: MantidWorkspace) -> bool:
     return "BL4B:CS:ExpPl:OperatingMode" in sample_logs and sample_logs["BL4B:CS:ExpPl:OperatingMode"] == "Free Liquid"
 
 
-def theta_log_name(log_source: MantidWorkspace | SampleLogSource) -> str:
+def theta_log_name(log_source: MantidWorkspace) -> str:
     """
     Return the sample log name that should be used for theta.
 
     Parameters
     ----------
-    log_source : MantidWorkspace | SampleLogSource
+    log_source : MantidWorkspace
         Workspace or mapping-like object containing the relevant sample log values.
 
     Returns

--- a/tests/unit/lr_reduction/test_data_info.py
+++ b/tests/unit/lr_reduction/test_data_info.py
@@ -21,10 +21,25 @@ def test_from_workspace_direct_beam_earth_centered_coordinates(mock_sample_logs_
 def test_from_workspace_direct_beam_free_liquid_mode(mock_sample_logs_class):
     """Test direct beam detection with free liquid mode"""
     mock_logs = {
-        "BL4B:CS:Mode:Coordinates": 1,
         "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
         "thi": 0.210,
         "tthd": 0.212,
+    }
+    mock_sample_logs_class.return_value = mock_logs
+
+    result = DataType.from_workspace(Mock())
+    assert result == DataType.DIRECT_BEAM
+
+
+@patch("lr_reduction.data_info.SampleLogValues")
+def test_from_workspace_coordinate_mode_overrides_legacy_operating_mode(mock_sample_logs_class):
+    """Beam-centered coordinate mode should win over the legacy Free Liquid fallback."""
+    mock_logs = {
+        "BL4B:CS:Mode:Coordinates": 1,
+        "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
+        "thi": 0.210,
+        "ths": 0.0006,
+        "tthd": 0.0008,
     }
     mock_sample_logs_class.return_value = mock_logs
 

--- a/tests/unit/lr_reduction/test_data_info.py
+++ b/tests/unit/lr_reduction/test_data_info.py
@@ -3,36 +3,48 @@ from unittest.mock import Mock, patch
 from lr_reduction.data_info import DataType
 
 
+def _set_mock_logs(*mock_classes, logs):
+    for mock_class in mock_classes:
+        mock_class.return_value = logs
+
+
+@patch("lr_reduction.theta_selection.SampleLogValues")
 @patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_direct_beam_earth_centered_coordinates(mock_sample_logs_class):
+def test_from_workspace_direct_beam_earth_centered_coordinates(
+    mock_data_info_sample_logs, mock_theta_selection_sample_logs
+):
     """Test direct beam detection with earth-centered coordinates"""
     mock_logs = {
         "BL4B:CS:Mode:Coordinates": 0,
         "thi": 0.800,
         "tthd": 0.805,
     }
-    mock_sample_logs_class.return_value = mock_logs
+    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
 
     result = DataType.from_workspace(Mock())
     assert result == DataType.DIRECT_BEAM
 
 
+@patch("lr_reduction.theta_selection.SampleLogValues")
 @patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_direct_beam_free_liquid_mode(mock_sample_logs_class):
+def test_from_workspace_direct_beam_free_liquid_mode(mock_data_info_sample_logs, mock_theta_selection_sample_logs):
     """Test direct beam detection with free liquid mode"""
     mock_logs = {
         "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
         "thi": 0.210,
         "tthd": 0.212,
     }
-    mock_sample_logs_class.return_value = mock_logs
+    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
 
     result = DataType.from_workspace(Mock())
     assert result == DataType.DIRECT_BEAM
 
 
+@patch("lr_reduction.theta_selection.SampleLogValues")
 @patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_coordinate_mode_overrides_legacy_operating_mode(mock_sample_logs_class):
+def test_from_workspace_coordinate_mode_overrides_legacy_operating_mode(
+    mock_data_info_sample_logs, mock_theta_selection_sample_logs
+):
     """Beam-centered coordinate mode should win over the legacy Free Liquid fallback."""
     mock_logs = {
         "BL4B:CS:Mode:Coordinates": 1,
@@ -41,28 +53,32 @@ def test_from_workspace_coordinate_mode_overrides_legacy_operating_mode(mock_sam
         "ths": 0.0006,
         "tthd": 0.0008,
     }
-    mock_sample_logs_class.return_value = mock_logs
+    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
 
     result = DataType.from_workspace(Mock())
     assert result == DataType.DIRECT_BEAM
 
 
+@patch("lr_reduction.theta_selection.SampleLogValues")
 @patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_reflected_beam_earth_centered(mock_sample_logs_class):
+def test_from_workspace_reflected_beam_earth_centered(mock_data_info_sample_logs, mock_theta_selection_sample_logs):
     """Test reflected beam detection with earth-centered coordinates"""
     mock_logs = {
         "BL4B:CS:Mode:Coordinates": 0,
         "thi": 0.5,
         "tthd": 1.0,
     }
-    mock_sample_logs_class.return_value = mock_logs
+    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
 
     result = DataType.from_workspace(Mock())
     assert result == DataType.REFLECTED_BEAM
 
 
+@patch("lr_reduction.theta_selection.SampleLogValues")
 @patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_reflected_beam_beam_centered(mock_sample_logs_class):
+def test_from_workspace_reflected_beam_beam_centered(
+    mock_data_info_sample_logs, mock_theta_selection_sample_logs
+):
     """Test reflected beam detection with beam-centered coordinates"""
     mock_logs = {
         "BL4B:CS:Mode:Coordinates": 1,
@@ -70,14 +86,15 @@ def test_from_workspace_reflected_beam_beam_centered(mock_sample_logs_class):
         "ths": 0.5,
         "tthd": 1.0,
     }
-    mock_sample_logs_class.return_value = mock_logs
+    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
 
     result = DataType.from_workspace(Mock())
     assert result == DataType.REFLECTED_BEAM
 
 
+@patch("lr_reduction.theta_selection.SampleLogValues")
 @patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_direct_beam_beam_centered(mock_sample_logs_class):
+def test_from_workspace_direct_beam_beam_centered(mock_data_info_sample_logs, mock_theta_selection_sample_logs):
     """Test direct beam detection with beam-centered coordinates"""
     mock_logs = {
         "BL4B:CS:Mode:Coordinates": 1,
@@ -85,16 +102,17 @@ def test_from_workspace_direct_beam_beam_centered(mock_sample_logs_class):
         "ths": 0.0006,
         "tthd": 0.0008,
     }
-    mock_sample_logs_class.return_value = mock_logs
+    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
 
     result = DataType.from_workspace(Mock())
     assert result == DataType.DIRECT_BEAM
 
 
+@patch("lr_reduction.theta_selection.SampleLogValues")
 @patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_missing_logs(mock_sample_logs_class):
+def test_from_workspace_missing_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs):
     """Test that missing logs default to reflected beam"""
-    mock_sample_logs_class.return_value = {}
+    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs={})
 
     result = DataType.from_workspace(Mock())
     assert result == DataType.REFLECTED_BEAM

--- a/tests/unit/lr_reduction/test_data_info.py
+++ b/tests/unit/lr_reduction/test_data_info.py
@@ -1,118 +1,121 @@
-from unittest.mock import Mock, patch
-
 from lr_reduction.data_info import DataType
 
 
-def _set_mock_logs(*mock_classes, logs):
-    for mock_class in mock_classes:
-        mock_class.return_value = logs
+class _FakeProperty:
+    def __init__(self, value):
+        self.value = value
 
 
-@patch("lr_reduction.theta_selection.SampleLogValues")
-@patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_direct_beam_earth_centered_coordinates(
-    mock_data_info_sample_logs, mock_theta_selection_sample_logs
-):
+class _FakeRun:
+    def __init__(self, logs):
+        self._logs = {name: _FakeProperty(value) for name, value in logs.items()}
+
+    def getProperty(self, key):  # noqa: N802
+        return self._logs[key]
+
+    def hasProperty(self, key):  # noqa: N802
+        return key in self._logs
+
+
+class _FakeWorkspace:
+    def __init__(self, logs):
+        self._run = _FakeRun(logs)
+
+    def getRun(self):  # noqa: N802
+        return self._run
+
+
+def test_from_workspace_direct_beam_earth_centered_coordinates():
     """Test direct beam detection with earth-centered coordinates"""
-    mock_logs = {
-        "BL4B:CS:Mode:Coordinates": 0,
-        "thi": 0.800,
-        "tthd": 0.805,
-    }
-    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
+    workspace = _FakeWorkspace(
+        {
+            "BL4B:CS:Mode:Coordinates": 0,
+            "thi": 0.800,
+            "tthd": 0.805,
+        }
+    )
 
-    result = DataType.from_workspace(Mock())
+    result = DataType.from_workspace(workspace)
     assert result == DataType.DIRECT_BEAM
 
 
-@patch("lr_reduction.theta_selection.SampleLogValues")
-@patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_direct_beam_free_liquid_mode(mock_data_info_sample_logs, mock_theta_selection_sample_logs):
+def test_from_workspace_direct_beam_free_liquid_mode():
     """Test direct beam detection with free liquid mode"""
-    mock_logs = {
-        "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
-        "thi": 0.210,
-        "tthd": 0.212,
-    }
-    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
+    workspace = _FakeWorkspace(
+        {
+            "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
+            "thi": 0.210,
+            "tthd": 0.212,
+        }
+    )
 
-    result = DataType.from_workspace(Mock())
+    result = DataType.from_workspace(workspace)
     assert result == DataType.DIRECT_BEAM
 
 
-@patch("lr_reduction.theta_selection.SampleLogValues")
-@patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_coordinate_mode_overrides_legacy_operating_mode(
-    mock_data_info_sample_logs, mock_theta_selection_sample_logs
-):
+def test_from_workspace_coordinate_mode_overrides_legacy_operating_mode():
     """Beam-centered coordinate mode should win over the legacy Free Liquid fallback."""
-    mock_logs = {
-        "BL4B:CS:Mode:Coordinates": 1,
-        "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
-        "thi": 0.210,
-        "ths": 0.0006,
-        "tthd": 0.0008,
-    }
-    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
+    workspace = _FakeWorkspace(
+        {
+            "BL4B:CS:Mode:Coordinates": 1,
+            "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
+            "thi": 0.210,
+            "ths": 0.0006,
+            "tthd": 0.0008,
+        }
+    )
 
-    result = DataType.from_workspace(Mock())
+    result = DataType.from_workspace(workspace)
     assert result == DataType.DIRECT_BEAM
 
 
-@patch("lr_reduction.theta_selection.SampleLogValues")
-@patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_reflected_beam_earth_centered(mock_data_info_sample_logs, mock_theta_selection_sample_logs):
+def test_from_workspace_reflected_beam_earth_centered():
     """Test reflected beam detection with earth-centered coordinates"""
-    mock_logs = {
-        "BL4B:CS:Mode:Coordinates": 0,
-        "thi": 0.5,
-        "tthd": 1.0,
-    }
-    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
+    workspace = _FakeWorkspace(
+        {
+            "BL4B:CS:Mode:Coordinates": 0,
+            "thi": 0.5,
+            "tthd": 1.0,
+        }
+    )
 
-    result = DataType.from_workspace(Mock())
+    result = DataType.from_workspace(workspace)
     assert result == DataType.REFLECTED_BEAM
 
 
-@patch("lr_reduction.theta_selection.SampleLogValues")
-@patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_reflected_beam_beam_centered(
-    mock_data_info_sample_logs, mock_theta_selection_sample_logs
-):
+def test_from_workspace_reflected_beam_beam_centered():
     """Test reflected beam detection with beam-centered coordinates"""
-    mock_logs = {
-        "BL4B:CS:Mode:Coordinates": 1,
-        "BL4B:CS:ExpPl:OperatingMode": "Other",
-        "ths": 0.5,
-        "tthd": 1.0,
-    }
-    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
+    workspace = _FakeWorkspace(
+        {
+            "BL4B:CS:Mode:Coordinates": 1,
+            "BL4B:CS:ExpPl:OperatingMode": "Other",
+            "ths": 0.5,
+            "tthd": 1.0,
+        }
+    )
 
-    result = DataType.from_workspace(Mock())
+    result = DataType.from_workspace(workspace)
     assert result == DataType.REFLECTED_BEAM
 
 
-@patch("lr_reduction.theta_selection.SampleLogValues")
-@patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_direct_beam_beam_centered(mock_data_info_sample_logs, mock_theta_selection_sample_logs):
+def test_from_workspace_direct_beam_beam_centered():
     """Test direct beam detection with beam-centered coordinates"""
-    mock_logs = {
-        "BL4B:CS:Mode:Coordinates": 1,
-        "BL4B:CS:ExpPl:OperatingMode": "Other",
-        "ths": 0.0006,
-        "tthd": 0.0008,
-    }
-    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs=mock_logs)
+    workspace = _FakeWorkspace(
+        {
+            "BL4B:CS:Mode:Coordinates": 1,
+            "BL4B:CS:ExpPl:OperatingMode": "Other",
+            "ths": 0.0006,
+            "tthd": 0.0008,
+        }
+    )
 
-    result = DataType.from_workspace(Mock())
+    result = DataType.from_workspace(workspace)
     assert result == DataType.DIRECT_BEAM
 
 
-@patch("lr_reduction.theta_selection.SampleLogValues")
-@patch("lr_reduction.data_info.SampleLogValues")
-def test_from_workspace_missing_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs):
+def test_from_workspace_missing_logs():
     """Test that missing logs default to reflected beam"""
-    _set_mock_logs(mock_data_info_sample_logs, mock_theta_selection_sample_logs, logs={})
+    workspace = _FakeWorkspace({})
 
-    result = DataType.from_workspace(Mock())
+    result = DataType.from_workspace(workspace)
     assert result == DataType.REFLECTED_BEAM

--- a/tests/unit/lr_reduction/test_template.py
+++ b/tests/unit/lr_reduction/test_template.py
@@ -1,6 +1,10 @@
+import math
+
+import numpy as np
 import pytest
 
-from lr_reduction.template import get_default_template_file
+from lr_reduction.reduction_template_reader import ReductionParameters
+from lr_reduction.template import get_default_template_file, process_from_template_ws
 
 
 def test_get_default_template_file_up_down_and_default(tmp_path):
@@ -25,3 +29,93 @@ def test_get_default_template_file_up_down_and_default(tmp_path):
     down_file = out / "template_down.xml"
     down_file.touch()
     assert get_default_template_file(str(out), -1) == str(down_file)
+
+
+class _FakeProperty:
+    def __init__(self, value):
+        self.value = [value]
+        self.size = 1
+
+
+class _FakeRun:
+    def __init__(self, logs):
+        self._logs = {name: _FakeProperty(value) for name, value in logs.items()}
+
+    def __contains__(self, key):
+        return key in self._logs
+
+    def __getitem__(self, key):
+        return self._logs[key]
+
+    def getProperty(self, key):  # noqa: N802
+        return self._logs[key]
+
+    def hasProperty(self, key):  # noqa: N802
+        return key in self._logs
+
+
+class _FakeWorkspace:
+    def __init__(self, logs):
+        self._run = _FakeRun(logs)
+
+    def getRun(self):  # noqa: N802
+        return self._run
+
+
+class _DummyEventReflectivity:
+    INSTRUMENT_4B = "REF_L"
+    captured_theta = None
+
+    def __init__(self, *_args, **kwargs):
+        self.theta = kwargs["theta"]
+        type(self).captured_theta = kwargs["theta"]
+
+    def specular(self, **_kwargs):
+        return np.array([0.1, 0.2, 0.3]), np.array([1.0, 2.0]), np.array([0.1, 0.2])
+
+    def to_dict(self):
+        return {}
+
+
+@pytest.mark.parametrize(
+    ("logs", "expected_theta"),
+    [
+        (
+            {
+                "LambdaRequest": 5.0,
+                "thi": 1.5,
+                "ths": 0.2,
+                "BL4B:CS:Mode:Coordinates": 0,
+                "BL4B:CS:ExpPl:OperatingMode": "Bound Liquid",
+            },
+            1.5,
+        ),
+        (
+            {
+                "LambdaRequest": 5.0,
+                "thi": 1.4,
+                "ths": 0.3,
+                "BL4B:CS:Mode:Coordinates": 1,
+                "BL4B:CS:ExpPl:OperatingMode": "Free Liquid",
+            },
+            0.3,
+        ),
+        (
+            {
+                "LambdaRequest": 5.0,
+                "thi": 1.3,
+                "ths": 0.4,
+                "BL4B:CS:Mode:Coordinates": 1,
+                "BL4B:CS:ExpPl:OperatingMode": "Bound Liquid",
+            },
+            0.4,
+        ),
+    ],
+)
+def test_process_from_template_ws_selects_theta_log(monkeypatch, logs, expected_theta):
+    template_data = ReductionParameters()
+    monkeypatch.setattr("lr_reduction.template.event_reduction.EventReflectivity", _DummyEventReflectivity)
+
+    process_from_template_ws(_FakeWorkspace(logs), template_data, normalize=False)
+
+    assert _DummyEventReflectivity.captured_theta == pytest.approx(math.radians(expected_theta))

--- a/tests/unit/lr_reduction/test_theta_selection.py
+++ b/tests/unit/lr_reduction/test_theta_selection.py
@@ -1,0 +1,30 @@
+import pytest
+
+from lr_reduction.theta_selection import theta_log_name, uses_incident_theta
+
+
+@pytest.mark.parametrize(
+    ("logs", "expected"),
+    [
+        ({"BL4B:CS:Mode:Coordinates": 0}, True),
+        ({"BL4B:CS:Mode:Coordinates": 1, "BL4B:CS:ExpPl:OperatingMode": "Free Liquid"}, False),
+        ({"BL4B:CS:Mode:Coordinates": 1, "BL4B:CS:ExpPl:OperatingMode": "Bound Liquid"}, False),
+        ({"BL4B:CS:ExpPl:OperatingMode": "Free Liquid"}, True),
+        ({}, False),
+    ],
+)
+def test_uses_incident_theta(logs, expected):
+    assert uses_incident_theta(logs) is expected
+
+
+@pytest.mark.parametrize(
+    ("logs", "expected"),
+    [
+        ({"BL4B:CS:Mode:Coordinates": 0}, "thi"),
+        ({"BL4B:CS:Mode:Coordinates": 1, "BL4B:CS:ExpPl:OperatingMode": "Free Liquid"}, "ths"),
+        ({"BL4B:CS:ExpPl:OperatingMode": "Free Liquid"}, "thi"),
+        ({"BL4B:CS:Mode:Coordinates": 1, "BL4B:CS:ExpPl:OperatingMode": "Bound Liquid"}, "ths"),
+    ],
+)
+def test_theta_log_name(logs, expected):
+    assert theta_log_name(logs) == expected

--- a/tests/unit/lr_reduction/test_theta_selection.py
+++ b/tests/unit/lr_reduction/test_theta_selection.py
@@ -3,6 +3,30 @@ import pytest
 from lr_reduction.theta_selection import is_earth_centered_geometry, theta_log_name
 
 
+class _FakeProperty:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeRun:
+    def __init__(self, logs):
+        self._logs = {name: _FakeProperty(value) for name, value in logs.items()}
+
+    def getProperty(self, key):  # noqa: N802
+        return self._logs[key]
+
+    def hasProperty(self, key):  # noqa: N802
+        return key in self._logs
+
+
+class _FakeWorkspace:
+    def __init__(self, logs):
+        self._run = _FakeRun(logs)
+
+    def getRun(self):  # noqa: N802
+        return self._run
+
+
 @pytest.mark.parametrize(
     ("logs", "expected"),
     [
@@ -14,7 +38,7 @@ from lr_reduction.theta_selection import is_earth_centered_geometry, theta_log_n
     ],
 )
 def test_is_earth_centered_geometry(logs, expected):
-    assert is_earth_centered_geometry(logs) is expected
+    assert is_earth_centered_geometry(_FakeWorkspace(logs)) is expected
 
 
 @pytest.mark.parametrize(
@@ -27,4 +51,4 @@ def test_is_earth_centered_geometry(logs, expected):
     ],
 )
 def test_theta_log_name(logs, expected):
-    assert theta_log_name(logs) == expected
+    assert theta_log_name(_FakeWorkspace(logs)) == expected

--- a/tests/unit/lr_reduction/test_theta_selection.py
+++ b/tests/unit/lr_reduction/test_theta_selection.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lr_reduction.theta_selection import theta_log_name, uses_incident_theta
+from lr_reduction.theta_selection import is_earth_centered_geometry, theta_log_name
 
 
 @pytest.mark.parametrize(
@@ -13,8 +13,8 @@ from lr_reduction.theta_selection import theta_log_name, uses_incident_theta
         ({}, False),
     ],
 )
-def test_uses_incident_theta(logs, expected):
-    assert uses_incident_theta(logs) is expected
+def test_is_earth_centered_geometry(logs, expected):
+    assert is_earth_centered_geometry(logs) is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description of work:
There is a problem affecting runs 229556-229561 that the instrument scientist thinks is because the wrong sample log is used for theta. Depending on whether the experiment is using "beam centered" or "earth centered" coordinate system, a different sample log should be used for the angle theta.

The problem shows up as failed reduction with the error:
`REDUCTION: negative dimensions are not allowed`

More info from the instrument scientist:

We found something I didn't expect in lr_reduction today (observed in refred and autoreduction) linked to the flags on different modes of operation and log values used. It was something I thought had been fixed previously but now seems to be wrong again. (I might have got confused on this last bit about what has been deployed.) The "theta" value to be used between thi and ths is dependent on the mode of operation of the beamline. The original method was that this always had to be set into a "Free Liquid" mode for using THI but this isn't strictly true and anything that is in the "Earth Centered" mode should be THI. This logic has been built into the data_info.py of lr_reduction and into gravity_correction, but seems to be missing elsewhere. For example in template.py which I think is the location causing the issue.

 This PR fixes the theta log selection for earth-centered reduction runs by changing theta-log selection to use `thi` for earth-centered runs and `ths` for beam-centered runs. `"Free Liquid"` handling is kept as a fallback only when the coordinate-mode log is missing. 
Adds tests covering earth-centered, beam-centered, and legacy mode behavior. 

Check all that apply:
- [ ] updated documentation
- [X] Source added/refactored
- [X] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [16408: [lr_reduction] Run mode not respected when selecting theta](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/16408)
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
