### PR TITLE
Publish package and trigger deploy on push to `exp`

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [next, qa, main]
+    branches: [next, qa, main, new_workflow]  # Temporarily include 'new_workflow' to enable publishing from that branch
     tags: ["v*"]
 
 env:
@@ -33,6 +33,12 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
           manifest-path: pyproject.toml
+
+      - name: Configure Git credentials for code.ornl.gov
+        env:
+          TOKEN: ${{ secrets.DATA_READ_TOKEN }}
+        run: |
+          git config --global url."https://gitlab-ci-token:${TOKEN}@code.ornl.gov/".insteadOf "https://code.ornl.gov/"
 
       - name: Download test data
         run: |
@@ -81,14 +87,15 @@ jobs:
           pixi run conda-build
           mkdir -p /tmp/local-channel/noarch
           cp *.conda /tmp/local-channel/noarch/
+          # extract version from the package file name "lr_reduction-<version>-<build>.conda"
+          echo "PKG_VERSION=$(ls *.conda | cut -d'-' -f2)" >> $GITHUB_ENV
 
       - name: Verify Conda Package
-        uses: neutrons/conda-verify@v0.1.2
+        uses: neutrons/conda-actions/pkg-verify@v1
         with:
           python-version: "3.11"
           local-channel: /tmp/local-channel
-          module-name: ${{ env.PKG_NAME }}
-          package-name: ${{ env.PKG_NAME }}
+          package-name: ${{ env.PKG_NAME }}=${{ env.PKG_VERSION }} # install exact version
           extra-channels: neutrons mantid
           extra-commands: |
             python -c "import lr_reduction"
@@ -103,14 +110,12 @@ jobs:
 
   publish:
     runs-on: ubuntu-24.04
-    needs: [tests, build]
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build]
+    if:  startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/new_workflow'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 100
-          fetch-tags: true
           ref: ${{ github.ref }}
 
       - name: Setup Pixi
@@ -122,20 +127,29 @@ jobs:
           name: artifact-conda-package
 
       - name: Upload package to anaconda
-        env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          IS_RC: ${{ contains(github.ref, 'rc') }}
-        run: |
-          # label is main or rc depending on the tag-name
-          CONDA_LABEL="main"
-          if [ "${IS_RC}" = "true" ]; then CONDA_LABEL="rc"; fi
-          echo pushing ${{ github.ref }} with label $CONDA_LABEL
-          pixi run anaconda upload --label $CONDA_LABEL --user neutrons ${{ env.PKG_NAME }}-*.conda
+        uses: neutrons/conda-actions/publish@v1
+        with:
+          anaconda-token: ${{ secrets.ANACONDA_TOKEN }}
+          organization: neutrons
+          package-path: ${{ env.PKG_NAME }}-*.conda
+          # Publish from 'new_workflow' under the 'exp' label; otherwise use the default
+          # label (empty string) which maps to 'dev', 'rc', or 'main' based on the branch.
+          label: ${{ github.ref == 'refs/heads/new_workflow' && 'exp' || '' }}
+
+      - name: Remove old packages
+        if: github.ref == 'refs/heads/next'
+        uses: neutrons/conda-actions/pkg-remove@v1
+        with:
+          anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
+          organization: neutrons
+          package_name: ${{ env.PKG_NAME }}
+          label: ${{ env.CONDA_LABEL }}
+          keep: 5
 
   # Trigger GitLab dev deploy pipeline
   deploy-dev:
     runs-on: ubuntu-latest
-    needs: [tests, build]
+    needs: [tests, build, publish]
     if: github.ref == 'refs/heads/next'
     steps:
       - name: Get Environment Name
@@ -159,3 +173,25 @@ jobs:
         with:
           body: |
             GitLab pipeline for ${{ steps.env_name.outputs.name }} has been submitted for this commit: ${{ steps.trigger.outputs.web_url }}
+
+  # Trigger GitLab exp deploy pipeline
+  deploy-exp:
+    runs-on: ubuntu-latest
+    needs: [build, publish]
+    if: github.ref == 'refs/heads/new_workflow'
+    steps:
+      - name: Trigger Exp Deploy
+        # use https://github.com/eic/trigger-gitlab-ci/pull/14 until merged
+        uses: eic/trigger-gitlab-ci@d984d8d53d871d2fdc1325639d94322da6e8747f
+        id: trigger
+        with:
+          url: https://code.ornl.gov
+          project_id: 21175
+          ref_name: main
+          token: ${{ secrets.GITLAB_DEPLOY_TOKEN }}
+
+      - name: Annotate commit
+        uses: peter-evans/commit-comment@v4
+        with:
+          body: |
+            GitLab pipeline for lr_reduction-exp has been submitted for this commit: ${{ steps.trigger.outputs.web_url }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [next, qa, main, new_workflow]  # Temporarily include 'new_workflow' to enable publishing from that branch
+    branches: [next, qa, main, exp]  # Temporarily include 'exp' to enable publishing from that branch
     tags: ["v*"]
 
 env:
@@ -111,7 +111,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     needs: [build]
-    if:  startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/new_workflow'
+    if:  startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/exp'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -132,9 +132,9 @@ jobs:
           anaconda-token: ${{ secrets.ANACONDA_TOKEN }}
           organization: neutrons
           package-path: ${{ env.PKG_NAME }}-*.conda
-          # Publish from 'new_workflow' under the 'exp' label; otherwise use the default
+          # Publish from 'exp' under the 'exp' label; otherwise use the default
           # label (empty string) which maps to 'dev', 'rc', or 'main' based on the branch.
-          label: ${{ github.ref == 'refs/heads/new_workflow' && 'exp' || '' }}
+          label: ${{ github.ref == 'refs/heads/exp' && 'exp' || '' }}
 
       - name: Remove old packages
         if: github.ref == 'refs/heads/next'
@@ -178,7 +178,7 @@ jobs:
   deploy-exp:
     runs-on: ubuntu-latest
     needs: [build, publish]
-    if: github.ref == 'refs/heads/new_workflow'
+    if: github.ref == 'refs/heads/exp'
     steps:
       - name: Trigger Exp Deploy
         # use https://github.com/eic/trigger-gitlab-ci/pull/14 until merged

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -137,7 +137,7 @@ jobs:
           label: ${{ github.ref == 'refs/heads/exp' && 'exp' || '' }}
 
       - name: Remove old packages
-        if: github.ref == 'refs/heads/next'
+        if: github.ref == 'refs/heads/next' || github.ref == 'refs/heads/exp'
         uses: neutrons/conda-actions/pkg-remove@v1
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN }}


### PR DESCRIPTION
## Description of work:

Note: PR into branch `exp`.

This enables publishing a package with the label `exp` from the `exp` branch and and triggers a re-deploy of the new "experimental" Pixi environment `lr_reduction-exp`.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
