### PR TITLE
Change versioningit format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,12 @@ method = "git"
 default-tag = "0.0.1"
 
 [tool.versioningit.next-version]
-method = "minor-release"
+method = "minor"
 
 [tool.versioningit.format]
-distance = "{version}+{distance}.{vcs}{rev}"
-dirty = "{version}+{distance}.{vcs}{rev}.dirty"
-distance-dirty = "{version}+{distance}.{vcs}{rev}"
+distance = "{next_version}.dev{committer_date:%Y%m%d%H%M%S}+{vcs}{rev}"
+dirty = "{version}"
+distance-dirty = "{next_version}.dev{committer_date:%Y%m%d%H%M%S}+{vcs}{rev}"
 
 [tool.versioningit.write]
 file = "src/lr_reduction/_version.py"


### PR DESCRIPTION
## Description of work:

Change versioningit format to include datetime stamp, since this ensures the version numbers are monotonically increasing and new packages replace old ones on Anaconda.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
