### PR TITLE
Exp 2026 06 06 edits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,5 +27,5 @@ repos:
       - id: pixi-lock-check
         name: pixi-lock-check
         entry: bash -c "PATH=$HOME/.pixi/bin:$PATH pixi lock --check"
-        stage: pre-push
+        stages: [pre-push]
         language: system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,22 @@ packages = ["src/lr_reduction", "src/lr_autoreduce"]
 [tool.versioningit.vcs]
 method = "git"
 default-tag = "0.0.1"
+# Only release tags (v1, v2.3, v2.10.0rc1, ...) are version candidates. Without
+# this, `git describe` (and thus versioningit) would pick up ANY tag at HEAD --
+# including the lightweight coordination tags the agentic workflow pushes
+# (qa/*, review/*, triage/*, analysis/*). A non-PEP440 tag like qa/cd-dialog-resize
+# then raises InvalidVersionError at build/env-prep time (looks like a "test infra"
+# failure). The match glob makes versioningit ignore every non-release tag.
+match = ["v[0-9]*"]
 
 [tool.versioningit.next-version]
+# "minor" bumps (e.g. v2.9.0rc1) -> next_version (e.g. 2.10.0) which drops the rc
+# "minor-release" would only strip the rc -> 2.9.0, which sorts LOWER.
 method = "minor"
 
+# Dev builds MUST be derived from {next_version}, not the raw {version} tag
+# so `lr_reduction = {version="*"}` in the pixi-deploy env would never deploy
+# appending {vcs}{rev} keeps the git hash for provenance.
 [tool.versioningit.format]
 distance = "{next_version}.dev{committer_date:%Y%m%d%H%M%S}+{vcs}{rev}"
 dirty = "{version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,19 @@ method = "git"
 default-tag = "0.0.1"
 
 [tool.versioningit.next-version]
-method = "minor-release"
+# "minor" bumps v2.9.0rc1 -> next_version 2.10.0 (drops the rc and increments the
+# minor); "minor-release" would only strip the rc -> 2.9.0, which sorts LOWER.
+method = "minor"
 
+# Dev builds MUST be derived from {next_version} (the bumped 2.10.0), not the raw
+# {version} tag (2.9.0rc1): a 2.9.0rc1+N string sorts BELOW an already-published
+# 2.10.0.devN, so `lr_reduction = {version="*"}` in the pixi-deploy env would never
+# select it (the autodeploy break of 2026-06-05). {vcs}{rev} keeps the git hash for
+# provenance. See tasking/plan/lr_reduction_exp/autodeploy-investigation.md.
 [tool.versioningit.format]
-distance = "{version}+{distance}.{vcs}{rev}"
-dirty = "{version}+{distance}.{vcs}{rev}.dirty"
-distance-dirty = "{version}+{distance}.{vcs}{rev}"
+distance = "{next_version}.dev{distance}+{vcs}{rev}"
+dirty = "{version}+{vcs}{rev}.dirty"
+distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"
 
 [tool.versioningit.write]
 file = "src/lr_reduction/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,13 @@ packages = ["src/lr_reduction", "src/lr_autoreduce"]
 [tool.versioningit.vcs]
 method = "git"
 default-tag = "0.0.1"
+# Only release tags (v1, v2.3, v2.10.0rc1, ...) are version candidates. Without
+# this, `git describe` (and thus versioningit) would pick up ANY tag at HEAD --
+# including the lightweight coordination tags the agentic workflow pushes
+# (qa/*, review/*, triage/*, analysis/*). A non-PEP440 tag like qa/cd-dialog-resize
+# then raises InvalidVersionError at build/env-prep time (looks like a "test infra"
+# failure). The match glob makes versioningit ignore every non-release tag.
+match = ["v[0-9]*"]
 
 [tool.versioningit.next-version]
 # "minor" bumps v2.9.0rc1 -> next_version 2.10.0 (drops the rc and increments the

--- a/src/lr_autoreduce/new_reduce_REF_L.py
+++ b/src/lr_autoreduce/new_reduce_REF_L.py
@@ -89,7 +89,7 @@ def parse_command_arguments():
         "--no_publish",
         dest="no_publish",
         action="store_true",
-        help="Do not upload the HTML report to the livedata server.",
+        help="Do not upload the HTML report to the livedata server or confirm data available.",
     )
     parser.add_argument("settings_file",nargs="?", default=None, type=str, help="Path to the settings JSON file.")
 
@@ -196,9 +196,8 @@ def autoreduce_new(
     save_report(report, os.path.join(output_dir, f'REF_L_{run_number}_new.html'))
     if publish:
         upload_report(report, run_number=run_number)
-
-    # Confirm data availability
-    confirm_data_availability(sample_logs)
+        # Confirm data availability
+        confirm_data_availability(sample_logs)
 
 
 def confirm_data_availability(sample_logs: SampleLogValues) -> None:
@@ -246,17 +245,19 @@ def generate_ref_plot(output, run_nums):
 if __name__ == "__main__":
     args = parse_command_arguments()
 
+    # positional parameters
     events_file_arg = args.events_file
     output_dir_arg = args.output_dir
 
+    # optional (keyword) parameters
     settings_file_arg = args.settings_file
     template_file_arg = args.template_file
-
-    publish_arg = True
-    if args.no_publish:
-        publish_arg = False
+    publish_arg = not args.no_publish
 
     print("Running new reduction")
     autoreduce_new(
-        events_file_arg, output_dir_arg, settings_file_arg,template_file_arg, publish_arg
+        events_file_arg, output_dir_arg,
+        setting_file=settings_file_arg,
+        template_file=template_file_arg,
+        publish=publish_arg
     )

--- a/src/lr_autoreduce/new_reduce_REF_L.py
+++ b/src/lr_autoreduce/new_reduce_REF_L.py
@@ -19,7 +19,7 @@ CLI Arguments
         (Optional) Not used, kept for compatibility with existing scripts.
     ``theta_offset``
         (Optional) Theta offset value.
-    ``--no_publish``
+    ``--no-publish`` (alias: ``--no_publish``)
         (Optional) If provided, do not upload HTML report to monitor.sns.gov.
 
 Usage
@@ -29,7 +29,7 @@ Usage
 
     python reduce_REF_L.py <events_file> <output_dir> [old_version_flag] \
 [template_file] [avg_overlap] [const_q] [fit_first_peak] [theta_offset] \
-[--no_publish]
+[--no-publish]
 
 """
 
@@ -41,14 +41,15 @@ from pathlib import Path
 
 from mantid import logger
 from mantid.simpleapi import LoadEventNexus
+from plot_publisher import plot1d
+
+import lr_reduction.new_reduction_from_file as nrff
 
 #from lr_reduction import workflow
 from lr_reduction.data_info import DataType
 from lr_reduction.mantid_utils import SampleLogValues
 from lr_reduction.template import get_default_template_file
 from lr_reduction.web_report import assemble_report, generate_report_sections, save_report, upload_report
-import lr_reduction.new_reduction_from_file as nrff
-from plot_publisher import plot1d
 
 # Name of the conda environment to use - required by autoreduction
 #CONDA_ENV = "lr_reduction"
@@ -79,8 +80,17 @@ def parse_command_arguments():
     parser.add_argument("const_q", nargs="?", default="false")
     parser.add_argument("fit_first_peak", nargs="?", default="false")
     parser.add_argument("theta_offset", nargs="?", default="0")
-    # Optional arguments
-    parser.add_argument("--no_publish", action="store_true", help="Do not upload HTML report to the livedata server.")
+    # Optional flag. Kebab-case (--no-publish) is the argparse convention for
+    # optional arguments; the snake_case --no_publish is kept as an alias so
+    # already-deployed callers (e.g. REF_L/shared autoreduce) keep working.
+    # Both map to dest "no_publish", so args.no_publish is unchanged.
+    parser.add_argument(
+        "--no-publish",
+        "--no_publish",
+        dest="no_publish",
+        action="store_true",
+        help="Do not upload the HTML report to the livedata server.",
+    )
     parser.add_argument("settings_file",nargs="?", default=None, type=str, help="Path to the settings JSON file.")
 
     return parser.parse_args()
@@ -116,21 +126,21 @@ def get_default_setting_file(output_dir: str, tthd: float) -> str:
     return setting_file
 
 def autoreduce_new(
-	events_file,
-	output_dir,
-	setting_file = None,
+    events_file,
+    output_dir,
+    setting_file = None,
     template_file = None,
-	publish = True):
+    publish = True):
 
     # Ensure output directory exists
     Path(output_dir).mkdir(parents=True, exist_ok=True)
-    
+
     # KEEP MANTID LOGIC HERE FOR NOW
     # Load workspace and sample logs
     ws = LoadEventNexus(Filename=events_file)
     sample_logs = SampleLogValues(ws)
     data_type = DataType.from_workspace(ws)
-    
+
     experiment_id = sample_logs["experiment_identifier"]
 
     match = re.search(r'REF_L_(\d+)', events_file)
@@ -157,7 +167,7 @@ def autoreduce_new(
         # Ensure output directory exists
         Path(savepath).mkdir(parents=True, exist_ok=True)
         override_params = {"Spath": savepath, "subname": subname}
-        output, plots, run_number_list, config_out = nrff.reduce_from_file([run_number], setting_file, experiment_id, plot=False, 
+        output, plots, run_number_list, config_out = nrff.reduce_from_file([run_number], setting_file, experiment_id, plot=False,
                 override_params = override_params, check_for_prior=True, save_pdf_summary=False)
         print('config out', vars(config_out))
         # Now have the config so can feed that in later...
@@ -177,7 +187,7 @@ def autoreduce_new(
         return
     else:
         raise ValueError(f"Unhandled data type: {data_type}")
-        
+
     # Save to disk and (optionally) upload the HTML report
     match = re.search(r'REF_L_(\d+)', events_file)
     if not match:
@@ -248,7 +258,5 @@ if __name__ == "__main__":
 
     print("Running new reduction")
     autoreduce_new(
-        events_file_arg, output_dir_arg, settings_file_arg,template_file_arg, publish_arg 
+        events_file_arg, output_dir_arg, settings_file_arg,template_file_arg, publish_arg
     )
-
-

--- a/src/lr_autoreduce/reduce_REF_L.py
+++ b/src/lr_autoreduce/reduce_REF_L.py
@@ -19,7 +19,7 @@ CLI Arguments
         (Optional) Not used, kept for compatibility with existing scripts.
     ``theta_offset``
         (Optional) Theta offset value.
-    ``--no_publish``
+    ``--no-publish`` (alias: ``--no_publish``)
         (Optional) If provided, do not upload HTML report to monitor.sns.gov.
 
 Usage
@@ -29,7 +29,7 @@ Usage
 
     python reduce_REF_L.py <events_file> <output_dir> [old_version_flag] \
 [template_file] [avg_overlap] [const_q] [fit_first_peak] [theta_offset] \
-[--no_publish]
+[--no-publish]
 
 """
 
@@ -77,8 +77,17 @@ def parse_command_arguments():
     parser.add_argument("const_q", nargs="?", default="false")
     parser.add_argument("fit_first_peak", nargs="?", default="false")
     parser.add_argument("theta_offset", nargs="?", default="0")
-    # Optional arguments
-    parser.add_argument("--no_publish", action="store_true", help="Do not upload HTML report to the livedata server.")
+    # Optional flag. Kebab-case (--no-publish) is the argparse convention for
+    # optional arguments; the snake_case --no_publish is kept as an alias so
+    # already-deployed callers (e.g. REF_L/shared autoreduce) keep working.
+    # Both map to dest "no_publish", so args.no_publish is unchanged.
+    parser.add_argument(
+        "--no-publish",
+        "--no_publish",
+        dest="no_publish",
+        action="store_true",
+        help="Do not upload the HTML report to the livedata server.",
+    )
 
     return parser.parse_args()
 

--- a/tests/test_versioningit_config.py
+++ b/tests/test_versioningit_config.py
@@ -1,0 +1,78 @@
+"""Guard the versioningit configuration against the 2026-06-05 autodeploy regression.
+
+Commit 5f1c70d changed the dev-build version format from `{next_version}.dev{distance}`
+(-> 2.10.0.dev80) to `{version}+{distance}.{vcs}{rev}` (-> 2.9.0rc1+86.g57f255c) and the
+next-version method from `minor` to `minor-release`. Both lowered the version: a
+`2.9.0rc1+N` string sorts BELOW the already-published `2.10.0.dev80`, so the deployment
+environment (`lr_reduction = {version="*"}` from the `neutrons/label/exp` channel) kept
+selecting the OLD build and the new code never deployed.
+
+These tests pin the invariant that fixed it: dev builds derive from {next_version} (the
+bumped version) via the `minor` method, while retaining the git hash for provenance.
+See tasking/plan/lr_reduction_exp/autodeploy-investigation.md for the full analysis.
+"""
+import os
+
+try:
+    import tomllib
+except ImportError:  # Python < 3.11
+    import tomli as tomllib
+
+_HERE = os.path.dirname(__file__)
+_PYPROJECT = os.path.join(_HERE, os.pardir, "pyproject.toml")
+
+
+def _versioningit_cfg():
+    with open(_PYPROJECT, "rb") as fh:
+        return tomllib.load(fh)["tool"]["versioningit"]
+
+
+def test_distance_format_uses_next_version_base():
+    """Dev builds must be derived from {next_version}, not the raw {version} tag.
+
+    Using the raw {version} (e.g. 2.9.0rc1) regresses the version below a prior
+    publish; {next_version} (e.g. 2.10.0) keeps it monotonically increasing.
+    """
+    fmt = _versioningit_cfg()["format"]
+    for key in ("distance", "distance-dirty"):
+        assert "{next_version}" in fmt[key], (
+            f"[tool.versioningit.format].{key} = {fmt[key]!r} must use {{next_version}} "
+            "so dev builds sort ABOVE prior releases. Using the raw {version} tag base "
+            "caused the 2026-06-05 autodeploy regression."
+        )
+        assert "{version}+" not in fmt[key], (
+            f"[tool.versioningit.format].{key} = {fmt[key]!r} uses the raw {{version}} "
+            "tag base directly; that is the regression. Use {next_version}."
+        )
+
+
+def test_next_version_method_bumps_minor():
+    """`minor` bumps 2.9.0rc1 -> 2.10.0; `minor-release` would only strip the rc -> 2.9.0
+    (lower). The monotonic-version fix requires the bumping method."""
+    assert _versioningit_cfg().get("next-version", {}).get("method") == "minor", (
+        "next-version method must be 'minor' (bumps the minor and drops the prerelease); "
+        "'minor-release' only strips the prerelease and sorts lower."
+    )
+
+
+def test_format_retains_git_hash():
+    """Keep the provenance commit 5f1c70d intended: the git revision in the version."""
+    assert "{vcs}{rev}" in _versioningit_cfg()["format"]["distance"], (
+        "the dev-build version should embed the git hash ({vcs}{rev}) for traceability."
+    )
+
+
+def test_computed_version_does_not_regress():
+    """Belt-and-suspenders: if versioningit is importable, the computed version's release
+    must be >= (2, 10, 0) so it sorts at/above the published 2.10.0.dev80 baseline."""
+    import pytest
+
+    versioningit = pytest.importorskip("versioningit")
+    from packaging.version import Version
+
+    raw = versioningit.get_version(project_dir=os.path.join(_HERE, os.pardir))
+    v = Version(raw.replace(".dirty", ""))
+    assert v.release >= (2, 10, 0), (
+        f"computed version {raw!r} (release {v.release}) regressed below the published "
+        "2.10.0.dev80 baseline; dev builds would be un-selectable by `version=\"*\"`."
+    )

--- a/tests/test_versioningit_config.py
+++ b/tests/test_versioningit_config.py
@@ -76,3 +76,34 @@ def test_computed_version_does_not_regress():
         f"computed version {raw!r} (release {v.release}) regressed below the published "
         "2.10.0.dev80 baseline; dev builds would be un-selectable by `version=\"*\"`."
     )
+
+
+def test_match_glob_present():
+    """The agentic workflow pushes lightweight coordination tags (qa/*, review/*,
+    triage/*, analysis/*). Without a release-tag allow-list, `git describe` could feed
+    one of those to versioningit -> InvalidVersionError at build/env-prep time. A
+    positive match glob keeps only release tags as version candidates. See
+    tasking/plan/lr_reduction_exp/findings.md F3."""
+    vcs = _versioningit_cfg()["vcs"]
+    assert "match" in vcs, (
+        "[tool.versioningit.vcs].match is required so versioningit ignores the workflow's "
+        "qa/*, review/*, triage/*, analysis/* coordination tags."
+    )
+    assert any("v" in g and "[0-9]" in g for g in vcs["match"]), (
+        f"unexpected match glob {vcs['match']!r}; expected a release-tag glob like ['v[0-9]*']."
+    )
+
+
+def test_match_glob_finds_a_release_tag():
+    """Sanity: the configured glob matches at least one tag reachable from HEAD, so
+    versioning still resolves (catches a future glob typo)."""
+    import re
+    import subprocess
+
+    globs = _versioningit_cfg()["vcs"]["match"]
+    cmd = ["git", "describe", "--tags", *(f"--match={g}" for g in globs), "HEAD"]
+    out = subprocess.run(cmd, capture_output=True, text=True, cwd=os.path.join(_HERE, os.pardir))
+    assert out.returncode == 0, f"git describe with match={globs} failed: {out.stderr!r}"
+    assert re.match(r"^v\d", out.stdout.strip()), (
+        f"git describe returned {out.stdout.strip()!r}; expected a v-prefixed release tag."
+    )


### PR DESCRIPTION
## Description of work:

~~Changes versioningit mistake introduced in a commit~~
Fixes a pre-commit hook on pixi-lock check that prevents commits if pixi.lock changes (not pushes as intended)
Fixes a versioningit issue when non-PEP440 versions are used
Updates handling of '--no-publish'
Incorporates #134 (developed concurrently)

Check all that apply:
- [ ] updated documentation
- [X] Source added/refactored
- [X] Added unit tests
- [ ] Added integration tests
- [X] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [X] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [X] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
