### PR TITLE
convert package.host-dependencies to explicit match spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,8 +132,8 @@ version = "0.0.0"  # a placeholder overwritten when Pixi task "sync-version" is 
 backend = { name = "pixi-build-python", version = ">=0.2,<1" }
 
 [tool.pixi.package.host-dependencies]
-hatchling= ">=1.27.0,<2"
-versioningit = "*"
+hatchling = { version = ">=1.27.0,<2" }
+versioningit = { version = "*" }
 
 
 ###################################


### PR DESCRIPTION
Suggested by: Github Copilot GPT5.5

- Why this should solve it

The backend pixi-build-python is rejecting the string form when parsing host dependencies during package build ([tool.pixi.package.build], backend = { name = "pixi-build-python", version = ">=0.2,<1" }). Converting these entries to explicit match-spec objects aligns the config with what the backend expects.

## Description of work:

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
