### PR TITLE
Fix autoreduce with sequence ordering issue

### DIFF
--- a/src/lr_autoreduce/new_reduce_REF_L.py
+++ b/src/lr_autoreduce/new_reduce_REF_L.py
@@ -157,6 +157,8 @@ def autoreduce_new(
         # Ensure output directory exists
         Path(savepath).mkdir(parents=True, exist_ok=True)
         override_params = {"Spath": savepath, "subname": subname}
+        run_number = int(run_number)
+        print('run_number_input', run_number, type(run_number))
         output, plots, run_number_list, config_out = nrff.reduce_from_file([run_number], setting_file, experiment_id, plot=False, 
                 override_params = override_params, check_for_prior=True, save_pdf_summary=False)
         print('config out', vars(config_out))

--- a/src/lr_reduction/example_nr_reduction_from_file.py
+++ b/src/lr_reduction/example_nr_reduction_from_file.py
@@ -119,6 +119,17 @@ def example_with_8col_search():
 
     return output
 
+def test_for_autoreduction():
+    run_list = [230395]
+    setting_file = "/SNS/REF_L/IPTS-35331/shared/autoreduce/reduce_settings_down.json"
+    experiment_id = "IPTS-35331"
+    Spath = Path('/SNS/REF_L/shared/lr_reduction/new_workflow_test_outputs/')
+    subname = "autoreduction"
+    override_params = {'Spath': Spath, "subname": subname}
+    output = reduction.reduce_from_file(run_list, setting_file, experiment_id, override_params=override_params, plot=True, save_json=False, check_for_prior=True, save_pdf_summary=False)
+
+    return output
+
 if __name__ == '__main__':
     # Run examples
     #example_from_dat()
@@ -129,7 +140,8 @@ if __name__ == '__main__':
     #example_with_savepdf()
     #example_with_savepdf_noshow()
     #example_with_search_savepdf()
-    example_with_8col()
-    example_with_8col_search()
+    #example_with_8col()
+    #example_with_8col_search()
+    test_for_autoreduction()
 
 

--- a/src/lr_reduction/new_reduction_from_file.py
+++ b/src/lr_reduction/new_reduction_from_file.py
@@ -89,50 +89,56 @@ def reduce_from_file(run_array, setting_file, experiment_id, datapath: Path = No
             # Look in folder for files of correct format
             dict_output, combine_results, scaling_factors, matched_files, sorted_run_nums, angle_logs = find_combine_priors(config_final, group_output_sorted["run_nums"], results, group_output_sorted, eight_col)
 
-            # check dictionaries and arrays aren't empty and pass if they are
-            if not dict_output:
-                continue
-            if not combine_results:
-                continue
-            if not scaling_factors:
-                continue
-            if not matched_files:
-                continue
+            # check dictionaries and arrays aren't empty - they're empty if no priors found
+            if dict_output:
+                # update the config scaling factors
+                config_final.ScaleFactor = scaling_factors
 
-            # update the config scaling factors
-            config_final.ScaleFactor = scaling_factors
-
-            # TODO: Need to read in the used_theta_vals
-            #used_theta_vals = {"thi":[], "ths":[], "ThCen":[], "title": []}
-            used_theta_vals = {k: angle_logs.get(k, []) + logs_out.get(k, []) for k in angle_logs.keys() | logs_out.keys()}
-            # save files
-            # non-concatenated
-            # TODO: this is resaving them. Think this is the best option.
-            for i in range(len(dict_output)):
-                save_fn.save_results(dict_output[i], config_final, used_theta_vals, sname=f"{config_final.Sname}_{i+1}_{sorted_run_nums[i]}{config_final.subname}")
-                if eight_col:
-                    save_fn.save_results(dict_output[i], config_final, used_theta_vals, sname=f"{config_final.Sname}_{i+1}_{sorted_run_nums[i]}{config_final.subname}", eight_column=True)
-            # Always make the final plot, only show it if plot is True
-            new_plot = plot_reflectivity(dict_output, RQ4=False, show_fig=plot)
-            figures_out.append(new_plot)
-            output_figures.append(new_plot)
-            # concatenated
-            try:
-                save_fn.save_results(combine_results, config_final, used_theta_vals, full=True, sname=f"{config_final.Sname}_combined{config_final.subname}")
-            except KeyError as e:
-                print(f"Warning: combined results missing expected key {e}; skipping save_results for combined output")
-            if eight_col:
+                # TODO: Need to read in the used_theta_vals
+                #used_theta_vals = {"thi":[], "ths":[], "ThCen":[], "title": []}
+                used_theta_vals = {k: angle_logs.get(k, []) + logs_out.get(k, []) for k in angle_logs.keys() | logs_out.keys()}
+                # save files
+                # non-concatenated
+                # TODO: this is resaving them. Think this is the best option.
+                for i in range(len(dict_output)):
+                    save_fn.save_results(dict_output[i], config_final, used_theta_vals, sname=f"{config_final.Sname}_{i+1}_{sorted_run_nums[i]}{config_final.subname}")
+                    if eight_col:
+                        save_fn.save_results(dict_output[i], config_final, used_theta_vals, sname=f"{config_final.Sname}_{i+1}_{sorted_run_nums[i]}{config_final.subname}", eight_column=True)
+                # Always make the final plot, only show it if plot is True
+                new_plot = plot_reflectivity(dict_output, RQ4=False, show_fig=plot)
+                figures_out.append(new_plot)
+                output_figures.append(new_plot)
+                # concatenated
                 try:
-                    save_fn.save_results(combine_results, config_final, used_theta_vals, eight_column=True, full=True, sname=f"{config_final.Sname}_combined{config_final.subname}")
+                    save_fn.save_results(combine_results, config_final, used_theta_vals, full=True, sname=f"{config_final.Sname}_combined{config_final.subname}")
                 except KeyError as e:
-                    print(f"Warning: combined results missing expected key {e}; skipping save_results (8col) for combined output")
+                    print(f"Warning: combined results missing expected key {e}; skipping save_results for combined output")
+                if eight_col:
+                    try:
+                        save_fn.save_results(combine_results, config_final, used_theta_vals, eight_column=True, full=True, sname=f"{config_final.Sname}_combined{config_final.subname}")
+                    except KeyError as e:
+                        print(f"Warning: combined results missing expected key {e}; skipping save_results (8col) for combined output")
 
-            if save_pdf_summary and plot:
-                # Overwrite output with new plot if created
-                save_fn.save_plot_pdf_summary(config_final.Spath, f"{config_final.Sname}{config_final.subname}", figures_out)
+                if save_pdf_summary and plot:
+                    # Overwrite output with new plot if created
+                    save_fn.save_plot_pdf_summary(config_final.Spath, f"{config_final.Sname}{config_final.subname}", figures_out)
 
-            all_results.append(dict_output)
+                all_results.append(dict_output)
+            else:
+                # when no priors found
+                # TODO: handling of other missing return parts from no priors found
+                print("No prior runs found")
+                for val in range(len(results["Q_per_run"])):
+                    to_add = {"Q": results["Q_per_run"][val],
+                              "R": results["R_per_run"][val],
+                              "dR": results["dR_per_run"][val],
+                              "dQ": results["dQ_per_run"][val]}
+
+                    all_results.append(to_add)
+                sorted_run_nums = group_output['run_nums'][idx]
+                all_results = [all_results]
         else:
+            # TODO: This should be made consistent with the searching for prior return too
             all_results.append(results)
             sorted_run_nums = group_output['run_nums'][idx]
         all_figures.extend(figures_out)
@@ -387,6 +393,8 @@ def find_combine_priors(updated_config, run_nums, results, group_output_sorted, 
                 print('Scaling factor:', np.round(scale, 3))
                 scaling_factors.append(scale)
                 position = sorted_seq_num[run] - 1
+                if position == len(initial_scalefactors):
+                    initial_scalefactors.append(1)
                 initial_scalefactors[position] *= scale
 
             Q.append(result[0, :])

--- a/src/lr_reduction/nr_reduction_calc.py
+++ b/src/lr_reduction/nr_reduction_calc.py
@@ -84,6 +84,14 @@ class NR_Reduction:
             if method not in valid_methods:
                 raise ValueError(f"Invalid method: {method}. Use one of {valid_methods}")
 
+        # Check method for useCalcTheta and deal with legacy use of "True"
+        valid_calc_theta = ['detector_angle', 'sample_angle']
+        if self.config.useCalcTheta:
+            if self.config.useCalcTheta == True:
+                self.config.useCalcTheta = 'detector_angle'
+            self.config.useCalcTheta = self.config.useCalcTheta.lower()
+            if self.config.useCalcTheta not in valid_calc_theta:
+                raise ValueError(f"Invalid calc theta method: {self.config.useCalcTheta}. Use one of {valid_calc_theta}")
 
         # Set defaults for optional arrays
         if not self.config.ThetaShift:
@@ -506,12 +514,9 @@ class NR_Reduction:
         RBpixel = par[1]
         dPix = RBpixel - DBpixel
         dMM = dPix * self.settings['pixel_width']
-        ThetaCalc = np.arcsin(dMM / self.settings['sample_detector_distance']) * 180 / np.pi
-        ThetaCalc = ThetaCalc + (self.log_values['tthd'] - DBtthd) / 2
-        if self.config.useCalcTheta:
-            print(f'Calculated theta: {np.round(ThetaCalc, 3)}, Theta correction applied: {np.round(ThetaCalc - ThCen, 3)}')
-        else:
-            print(f'Calculated theta: {np.round(ThetaCalc, 3)}, Theta difference: {np.round(ThetaCalc - ThCen, 3)} (not applied)')
+        alpha = np.arcsin(dMM / self.settings['sample_detector_distance']) * 180 / np.pi
+        ThetaCalc = alpha * 0.5 + (self.log_values['tthd'] - DBtthd) / 2
+        
         # TODO: Alter the function to do the calculation once and apply different angle offsets
         # Calculate expected beam profile on detector using logs
         Icalc_nonfit = tools.calc_beam_on_detector(Yfit, DBpixel, self.log_values['siY'], self.log_values['s1Y'],
@@ -519,18 +524,26 @@ class NR_Reduction:
                                          self.settings['sample_detector_distance'], self.settings['pixel_width'],
                                          self.config.DetSigma, self.config.DetResFn)
 
+        if not self.config.useCalcTheta:
+            print(f'Calculated theta: {np.round(ThetaCalc, 3)}, Theta difference: {np.round(ThetaCalc - ThCen, 3)} (not applied)')
+            RBpixel = DBpixel
+            Icalc = Icalc_nonfit
+
         # Use calculated value if flag
-        if self.config.useCalcTheta:
-            ThCen = ThetaCalc
-            self.log_values['ThCen'] = ThCen
+        else:
+            if self.config.useCalcTheta == 'detector_angle':
+                print(f'Calculated theta: {np.round(ThetaCalc, 3)}, Theta correction applied: {np.round(ThetaCalc - ThCen, 3)}') 
+                ThCen = ThetaCalc
+            else:
+                print(f'Calculated theta: {np.round(ThetaCalc, 3)}, Theta correction applied: {np.round(ThetaCalc - ThCen, 3)}')         ## TODO: Work out fixing the print statement here.    
+                ThCen = self.log_values['ths']
+            self.log_values['ThCen'] = ThCen            
+
             # Calculate expected beam profile on detector using logs
             Icalc = tools.calc_beam_on_detector(Yfit, RBpixel, self.log_values['siY'], self.log_values['s1Y'],
                                         self.settings['interslit_distance'], self.settings['si_sample_distance'],
                                         self.settings['sample_detector_distance'], self.settings['pixel_width'],
                                         self.config.DetSigma, self.config.DetResFn)
-        else:
-            RBpixel = DBpixel
-            Icalc = Icalc_nonfit
 
         Icalc = (Icalc * par[0]) + bkg
         Icalc_nonfit = (Icalc_nonfit * par[0]) + bkg


### PR DESCRIPTION
## Description of work:
Autoreduce failed when the searching for runs with the sequences completed out of order. This has been patched. There is more to clean-up here in the longer term.


Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
