### PR TITLE
Add YAML and XML modules as siblings to `orso.py`

### DIFF
--- a/src/lr_reduction/io/config_loader.py
+++ b/src/lr_reduction/io/config_loader.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
-from lr_reduction.config.model import DirectBeamConfig, ReductionConfig, ReflectedRunConfig
+from lr_reduction.config.model import ReductionConfig
 from lr_reduction.io.interfaces import ConfigLoaderInterface
 from lr_reduction.io.orso import read_config as read_orso_config
-from lr_reduction.utils import deprecated, get_logger, get_sequence_id_from_path
+from lr_reduction.io.xml import read_config as read_xml_config
+from lr_reduction.io.yaml import read_config as read_yaml_config
+from lr_reduction.utils import deprecated, get_logger
 
 logger = get_logger(__name__)
 
@@ -27,19 +29,11 @@ class ConfigLoader(ConfigLoaderInterface):
         if not loader:
             raise ValueError(f"Unsupported configuration file format: {fp.suffix}")
 
-        sequence_id = get_sequence_id_from_path(fp)
-        return loader(sequence_id)
+        return loader(str(fp))
 
     def _load_config(self, path: str) -> ReductionConfig:
-        """Load a ReductionConfig from a configuration file."""
-        sequence_id = get_sequence_id_from_path(path)
-        dbs = DirectBeamConfig(name="PLACEHOLDER NAME", db_runs=["PLACEHOLDER DB RUNS"])
-        refs = ReflectedRunConfig(run_id="PLACEHOLDER REF RUN", direct_beam=dbs.name)
-        return ReductionConfig(
-            sequence_id=sequence_id,
-            direct_beams=[dbs],
-            reflected_runs=[refs],
-        )
+        """Load a ReductionConfig from a YAML configuration file."""
+        return read_yaml_config(path)
 
     def _load_orso(self, path: str) -> ReductionConfig:
         """Load a ReductionConfig from an ORSO file."""
@@ -48,11 +42,4 @@ class ConfigLoader(ConfigLoaderInterface):
     @deprecated("XML config files are deprecated. Please use YAML or ORSO format instead.")
     def _load_xml(self, path: str) -> ReductionConfig:
         """Legacy method to load a ReductionConfig from an XML file, for backward compatibility."""
-        sequence_id = get_sequence_id_from_path(path)
-        dbs = DirectBeamConfig(name="PLACEHOLDER NAME", db_runs=["PLACEHOLDER DB RUNS"])
-        refs = ReflectedRunConfig(run_id="PLACEHOLDER REF RUN", direct_beam=dbs.name)
-        return ReductionConfig(
-            sequence_id=sequence_id,
-            direct_beams=[dbs],
-            reflected_runs=[refs],
-        )
+        return read_xml_config(path)

--- a/src/lr_reduction/io/orso.py
+++ b/src/lr_reduction/io/orso.py
@@ -1,7 +1,5 @@
 """ORSO format I/O module."""
 
-from pathlib import Path
-
 from orsopy import fileio
 
 from lr_reduction.config.model import DirectBeamConfig, ReductionConfig, ReflectedRunConfig
@@ -35,4 +33,7 @@ def read_partials(partial_dir: str, sequence_id: int) -> list[SingleRunResult]:
     ...
 
 
-def write(results: SingleRunResult | SequenceResult, output_dir: str | Path = "."): ...
+def write(result: SingleRunResult | SequenceResult, output_dir: str = ".") -> str:
+    """Persist *result* as an ORSO file under *output_dir* and return the path written."""
+    logger.info(f"Writing ORSO reduced data for {type(result).__name__} to {output_dir}")
+    ...

--- a/src/lr_reduction/io/xml.py
+++ b/src/lr_reduction/io/xml.py
@@ -1,0 +1,19 @@
+"""Legacy XML I/O module. Reads legacy RefRed XML templates as configuration input."""
+
+from lr_reduction.config.model import DirectBeamConfig, ReductionConfig, ReflectedRunConfig
+from lr_reduction.utils import get_logger, get_sequence_id_from_path
+
+logger = get_logger(__name__)
+
+
+def read_config(filepath: str) -> ReductionConfig:
+    """Read a legacy XML template and convert it to a ReductionConfig."""
+    logger.info(f"Reading legacy XML configuration from {filepath}")
+    sequence_id = get_sequence_id_from_path(filepath)
+    dbs = DirectBeamConfig(name="PLACEHOLDER NAME", db_runs=["PLACEHOLDER DB RUNS"])
+    refs = ReflectedRunConfig(run_id="PLACEHOLDER REF RUN", direct_beam=dbs.name)
+    return ReductionConfig(
+        sequence_id=sequence_id,
+        direct_beams=[dbs],
+        reflected_runs=[refs],
+    )

--- a/src/lr_reduction/io/yaml.py
+++ b/src/lr_reduction/io/yaml.py
@@ -1,0 +1,19 @@
+"""YAML I/O module. YAML is the native configuration format."""
+
+from lr_reduction.config.model import DirectBeamConfig, ReductionConfig, ReflectedRunConfig
+from lr_reduction.utils import get_logger, get_sequence_id_from_path
+
+logger = get_logger(__name__)
+
+
+def read_config(filepath: str) -> ReductionConfig:
+    """Read a YAML configuration file and return a validated ReductionConfig."""
+    logger.info(f"Reading YAML configuration from {filepath}")
+    sequence_id = get_sequence_id_from_path(filepath)
+    dbs = DirectBeamConfig(name="PLACEHOLDER NAME", db_runs=["PLACEHOLDER DB RUNS"])
+    refs = ReflectedRunConfig(run_id="PLACEHOLDER REF RUN", direct_beam=dbs.name)
+    return ReductionConfig(
+        sequence_id=sequence_id,
+        direct_beams=[dbs],
+        reflected_runs=[refs],
+    )


### PR DESCRIPTION
## Description of work:

Add separate modules for YAML and XML stubs to make the structure similar for all three config formats. (The story only listed orso.py...)

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
