### PR TITLE
No need to convert Mantid algo parameters to strings

### DIFF
--- a/src/lr_reduction/dead_time_correction.py
+++ b/src/lr_reduction/dead_time_correction.py
@@ -70,9 +70,9 @@ class SingleReadoutDeadTimeCorrection(PythonAlgorithm):
         if tof_min == 0 and tof_max == 0:
             tof_min = ws_event_data.getTofMin()
             tof_max = ws_event_data.getTofMax()
-        logger.notice("TOF range: %f %f" % (tof_min, tof_max))
+        logger.notice(f"TOF range: {tof_min} {tof_max}")
         _ws_sc = Rebin(
-            InputWorkspace=ws_event_data, Params="%s,%s,%s" % (tof_min, tof_step, tof_max), PreserveEvents=False
+            InputWorkspace=ws_event_data, Params=(tof_min, tof_step, tof_max), PreserveEvents=False
         )
 
         # Get the total number of counts on the detector for each TOF bin per pulse
@@ -81,7 +81,7 @@ class SingleReadoutDeadTimeCorrection(PythonAlgorithm):
         # If we have error events, add them since those are also detector triggers
         if ws_error_events is not None:
             _errors = Rebin(
-                InputWorkspace=ws_error_events, Params="%s,%s,%s" % (tof_min, tof_step, tof_max), PreserveEvents=False
+                InputWorkspace=ws_error_events, Params=(tof_min, tof_step, tof_max), PreserveEvents=False
             )
             counts_ws += _errors
 
@@ -114,7 +114,7 @@ class SingleReadoutDeadTimeCorrection(PythonAlgorithm):
             logger.notice("DeadTimeThreshold not used")
 
         if np.min(corr) < 0:
-            error = "Corrupted dead time correction:\n" + "  Reflected: %s\n" % corr
+            error = f"Corrupted dead time correction:\n  Reflected: {corr}\n"
             logger.error(error)
 
         counts_ws.setY(0, corr)


### PR DESCRIPTION
## Description of work:

Remove unnecessary conversion to strings.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Verified that tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

## :warning: Manual test for the reviewer
(Instructions for testing here)

## Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
