### PR TITLE
Restructure result models around a shared ReflectivityCurve

### DIFF
--- a/src/lr_reduction/api/_shared.py
+++ b/src/lr_reduction/api/_shared.py
@@ -12,12 +12,11 @@ from datetime import datetime
 from pathlib import Path
 
 import mantid
-import numpy as np
 from orsopy.fileio import Software
 
 from lr_reduction import __version__
 from lr_reduction.models.config import ReductionConfig
-from lr_reduction.models.results import CombinedReductionResult, ReductionResult
+from lr_reduction.models.results import CombinedReductionResult, ReductionResult, ReflectivityCurve
 from lr_reduction.utils import get_logger
 
 logger = get_logger(__name__)
@@ -45,11 +44,17 @@ def locate_configuration_relative_to(output_directory: Path) -> Path:
 
 
 def placeholder_single_run_result(config: ReductionConfig) -> ReductionResult:
-    """Fabricate a ReductionResult until Op 1 (direct beam) / Op 2 (single-run reduce) exist (§1.2)."""
+    """Fabricate a ReductionResult until Op 1 (direct beam) / Op 2 (single-run reduce) exist (§1.2).
+
+    Identity fields are zeroed: the real values come from the run's NeXus logs (§3.1.2),
+    which the placeholder never sees.
+    """
     return ReductionResult(
-        reflectivity=np.empty((0, 4)),
+        curve=ReflectivityCurve.empty(),
+        run_numbers=[],
+        sequence_id=0,
+        sequence_number=0,
         reduction_config=config,
-        html_report=None,
         lr_reduction_info=_LR_REDUCTION_SOFTWARE,
         mantid_info=_MANTID_SOFTWARE,
         reduction_timestamp=datetime.now(),
@@ -59,11 +64,9 @@ def placeholder_single_run_result(config: ReductionConfig) -> ReductionResult:
 def placeholder_sequence_result(config: ReductionConfig) -> CombinedReductionResult:
     """Fabricate a CombinedReductionResult until Op 3 (assembly) exists (§1.2)."""
     return CombinedReductionResult(
-        reflectivity=np.empty((0, 4)),
+        curve=ReflectivityCurve.empty(),
         reduction_config=config,
-        html_report=None,
         lr_reduction_info=_LR_REDUCTION_SOFTWARE,
         mantid_info=_MANTID_SOFTWARE,
         reduction_timestamp=datetime.now(),
-        assembly_config=config.assembly,
     )

--- a/src/lr_reduction/exceptions/__init__.py
+++ b/src/lr_reduction/exceptions/__init__.py
@@ -12,6 +12,11 @@ from lr_reduction.exceptions.config import (
     ConfigParseError,
     ConfigValidationError,
 )
+from lr_reduction.exceptions.results import (
+    IncompleteDataError,
+    MalformedDataError,
+    ResultError,
+)
 
 __all__ = [
     "ConfigError",
@@ -19,9 +24,12 @@ __all__ = [
     "ConfigNotFoundError",
     "ConfigParseError",
     "ConfigValidationError",
+    "IncompleteDataError",
     "LrReductionError",
     "LrValidationError",
+    "MalformedDataError",
     "NotFoundError",
     "ParseError",
+    "ResultError",
     "UnsupportedFormatError",
 ]

--- a/src/lr_reduction/exceptions/results.py
+++ b/src/lr_reduction/exceptions/results.py
@@ -1,0 +1,15 @@
+"""Exceptions raised while constructing or validating reduction results."""
+
+from lr_reduction.exceptions.base import LrReductionError, LrValidationError
+
+
+class ResultError(LrReductionError):
+    """Base for any failure constructing or validating a reduction result."""
+
+
+class IncompleteDataError(ResultError, LrValidationError):
+    """Only part of a column group that must be supplied together was provided."""
+
+
+class MalformedDataError(ResultError, LrValidationError):
+    """A data column has the wrong dimensionality or an inconsistent length."""

--- a/src/lr_reduction/models/results.py
+++ b/src/lr_reduction/models/results.py
@@ -1,38 +1,146 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 
 import numpy as np
 import numpy.typing as npt
 from orsopy.fileio import Software
 
-from lr_reduction.models.config import AssemblyConfig, ReductionConfig
+from lr_reduction.models.config import ReductionConfig
+
+
+@dataclass
+class ReflectivityCurve:
+    """The reduced R(Q) data carried by both result types.
+
+    Columns are stored as named arrays; the on-disk column order (Q, R, dR, dQ,
+    then T, L, dT, dL when present) is produced by :meth:`to_array`, so producers
+    never assemble positional columns themselves.
+
+    Attributes
+    ----------
+    q
+        Momentum transfer [1/Angstrom]
+    r
+        Reflectivity
+    dr
+        Reflectivity uncertainty
+    dq
+        Q resolution [1/Angstrom]
+    theta
+        Incidence angle [deg]; the optional 8-column T column
+    lam
+        Wavelength [Angstrom]; the optional 8-column L column
+    dtheta
+        Incidence angle uncertainty [deg]
+    dlam
+        Wavelength uncertainty [Angstrom]
+    """
+
+    q: npt.NDArray[np.float64]
+    r: npt.NDArray[np.float64]
+    dr: npt.NDArray[np.float64]
+    dq: npt.NDArray[np.float64]
+    theta: npt.NDArray[np.float64] | None = None
+    lam: npt.NDArray[np.float64] | None = None
+    dtheta: npt.NDArray[np.float64] | None = None
+    dlam: npt.NDArray[np.float64] | None = None
+
+    def __post_init__(self):
+        eight_column = [self.theta, self.lam, self.dtheta, self.dlam]
+        if any(column is not None for column in eight_column) and not all(
+            column is not None for column in eight_column
+        ):
+            raise ValueError("theta, lam, dtheta, dlam must be provided together")
+
+    @property
+    def is_eight_column(self) -> bool:
+        return self.theta is not None
+
+    def to_array(self) -> npt.NDArray[np.float64]:
+        """Return the curve as an (N, 4) or (N, 8) array in on-disk column order."""
+        columns = [self.q, self.r, self.dr, self.dq]
+        if self.is_eight_column:
+            columns += [self.theta, self.lam, self.dtheta, self.dlam]
+        return np.column_stack(columns)
+
+    @classmethod
+    def empty(cls) -> "ReflectivityCurve":
+        """Return a zero-point curve, used by placeholder results until Op 2/Op 3 exist."""
+        return cls(q=np.empty(0), r=np.empty(0), dr=np.empty(0), dq=np.empty(0))
 
 
 @dataclass
 class ReductionResult:
-    """Result of reducing data from a single run.
+    """Result of reducing a single run: one ORSO partial.
 
     Attributes
     ----------
-    TBD
+    curve
+        The reduced R(Q) data; not necessarily Q-sorted
+    run_numbers
+        Constituent run number(s); more than one when the run is a sum of
+        source runs, one data_files entry each
+    sequence_id
+        Identifies the reflectivity curve this run belongs to
+    sequence_number
+        1-based position of the run within the sequence
+    reduction_config
+        The one-run configuration that reproduces this partial when embedded
+        in its ORSO header
+    lr_reduction_info
+        lr_reduction package information
+    mantid_info
+        mantid package information
+    reduction_timestamp
+        orsopy.fileio.reduction.timestamp
     """
 
-    reflectivity: npt.NDArray[np.float64]
+    curve: ReflectivityCurve
+    run_numbers: list[int]
+    sequence_id: int
+    sequence_number: int
     reduction_config: ReductionConfig
-    html_report: str | None
-    # Reduction metadata
-    lr_reduction_info: Software  # lr_reduction package information
-    mantid_info: Software  # mantid package information
-    reduction_timestamp: datetime  # orsopy.fileio.reduction.timestamp
+    lr_reduction_info: Software
+    mantid_info: Software
+    reduction_timestamp: datetime
 
 
 @dataclass
-class CombinedReductionResult(ReductionResult):
-    """Result of assembling reduced data from multiple runs.
+class CombinedReductionResult:
+    """Result of assembling a sequence: one combined ORSO file.
+
+    Not a subclass of ReductionResult: a combined curve must not be accepted
+    where a single-run partial is expected (e.g. as sequence-assembly input).
 
     Attributes
     ----------
-    TBD
+    curve
+        The assembled curve, Q-monotone
+    partials
+        The single-run results the curve was assembled from, whether reduced
+        in-memory or loaded from on-disk partials; supplies the data_files
+        and additional_files entries of the combined output
+    scale_factors
+        Per-angle stitching scale factors computed by assembly, recorded in
+        the ORSO header
+    reduction_config
+        The full sequence configuration that reproduces this curve when
+        embedded in the ORSO header
+    html_report
+        Diagnostic HTML report for the sequence
+    lr_reduction_info
+        lr_reduction package information
+    mantid_info
+        mantid package information
+    reduction_timestamp
+        orsopy.fileio.reduction.timestamp
     """
 
-    assembly_config: AssemblyConfig
+    curve: ReflectivityCurve
+    reduction_config: ReductionConfig
+    lr_reduction_info: Software
+    mantid_info: Software
+    reduction_timestamp: datetime
+    partials: list[ReductionResult] = field(default_factory=list)
+    scale_factors: list[float] = field(default_factory=list)
+    html_report: str | None = None

--- a/src/lr_reduction/models/results.py
+++ b/src/lr_reduction/models/results.py
@@ -46,11 +46,23 @@ class ReflectivityCurve:
     dlam: npt.NDArray[np.float64] | None = None
 
     def __post_init__(self):
-        eight_column = [self.theta, self.lam, self.dtheta, self.dlam]
-        if any(column is not None for column in eight_column) and not all(
-            column is not None for column in eight_column
+        optional_columns = [self.theta, self.lam, self.dtheta, self.dlam]
+        if any(column is not None for column in optional_columns) and not all(
+            column is not None for column in optional_columns
         ):
             raise ValueError("theta, lam, dtheta, dlam must be provided together")
+
+        columns = [
+            self.q,
+            self.r,
+            self.dr,
+            self.dq,
+            *(column for column in optional_columns if column is not None),
+        ]
+        if any(column.ndim != 1 for column in columns):
+            raise ValueError("reflectivity curve columns must be one-dimensional")
+        if len({len(column) for column in columns}) != 1:
+            raise ValueError("reflectivity curve columns must have equal lengths")
 
     @property
     def is_eight_column(self) -> bool:

--- a/src/lr_reduction/models/results.py
+++ b/src/lr_reduction/models/results.py
@@ -5,7 +5,9 @@ import numpy as np
 import numpy.typing as npt
 from orsopy.fileio import Software
 
+from lr_reduction.exceptions import IncompleteDataError, MalformedDataError
 from lr_reduction.models.config import ReductionConfig
+from lr_reduction.types import ID
 
 
 @dataclass
@@ -50,7 +52,7 @@ class ReflectivityCurve:
         if any(column is not None for column in optional_columns) and not all(
             column is not None for column in optional_columns
         ):
-            raise ValueError("theta, lam, dtheta, dlam must be provided together")
+            raise IncompleteDataError("theta, lam, dtheta, dlam must be provided together")
 
         columns = [
             self.q,
@@ -60,9 +62,9 @@ class ReflectivityCurve:
             *(column for column in optional_columns if column is not None),
         ]
         if any(column.ndim != 1 for column in columns):
-            raise ValueError("reflectivity curve columns must be one-dimensional")
+            raise MalformedDataError("reflectivity curve columns must be one-dimensional")
         if len({len(column) for column in columns}) != 1:
-            raise ValueError("reflectivity curve columns must have equal lengths")
+            raise MalformedDataError("reflectivity curve columns must have equal lengths")
 
     @property
     def is_eight_column(self) -> bool:
@@ -108,9 +110,9 @@ class ReductionResult:
     """
 
     curve: ReflectivityCurve
-    run_numbers: list[int]
-    sequence_id: int
-    sequence_number: int
+    run_numbers: list[ID]
+    sequence_id: ID
+    sequence_number: ID
     reduction_config: ReductionConfig
     lr_reduction_info: Software
     mantid_info: Software

--- a/tests/unit/models/test_results.py
+++ b/tests/unit/models/test_results.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pytest
+
+from lr_reduction.models.results import ReflectivityCurve
+
+
+def _four_columns():
+    return {
+        "q": np.array([0.01, 0.02]),
+        "r": np.array([1.0, 0.5]),
+        "dr": np.array([0.1, 0.05]),
+        "dq": np.array([0.001, 0.002]),
+    }
+
+
+def test_to_array_four_column_order():
+    curve = ReflectivityCurve(**_four_columns())
+    array = curve.to_array()
+    assert array.shape == (2, 4)
+    np.testing.assert_array_equal(array[:, 0], curve.q)
+    np.testing.assert_array_equal(array[:, 1], curve.r)
+    np.testing.assert_array_equal(array[:, 2], curve.dr)
+    np.testing.assert_array_equal(array[:, 3], curve.dq)
+    assert not curve.is_eight_column
+
+
+def test_to_array_eight_column_order():
+    curve = ReflectivityCurve(
+        **_four_columns(),
+        theta=np.array([0.6, 0.6]),
+        lam=np.array([4.0, 5.0]),
+        dtheta=np.array([0.01, 0.01]),
+        dlam=np.array([0.04, 0.05]),
+    )
+    array = curve.to_array()
+    assert array.shape == (2, 8)
+    np.testing.assert_array_equal(array[:, 4], curve.theta)
+    np.testing.assert_array_equal(array[:, 5], curve.lam)
+    np.testing.assert_array_equal(array[:, 6], curve.dtheta)
+    np.testing.assert_array_equal(array[:, 7], curve.dlam)
+    assert curve.is_eight_column
+
+
+def test_partial_eight_column_rejected():
+    with pytest.raises(ValueError, match="provided together"):
+        ReflectivityCurve(**_four_columns(), theta=np.array([0.6, 0.6]))
+
+
+def test_empty_curve():
+    curve = ReflectivityCurve.empty()
+    assert curve.to_array().shape == (0, 4)

--- a/tests/unit/models/test_results.py
+++ b/tests/unit/models/test_results.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from lr_reduction.exceptions import IncompleteDataError, MalformedDataError
 from lr_reduction.models.results import ReflectivityCurve
 
 
@@ -42,8 +43,22 @@ def test_to_array_eight_column_order():
 
 
 def test_partial_eight_column_rejected():
-    with pytest.raises(ValueError, match="provided together"):
+    with pytest.raises(IncompleteDataError, match="provided together"):
         ReflectivityCurve(**_four_columns(), theta=np.array([0.6, 0.6]))
+
+
+def test_multidimensional_column_rejected():
+    columns = _four_columns()
+    columns["r"] = np.ones((2, 2))
+    with pytest.raises(MalformedDataError, match="one-dimensional"):
+        ReflectivityCurve(**columns)
+
+
+def test_mismatched_column_length_rejected():
+    columns = _four_columns()
+    columns["dq"] = np.array([0.001, 0.002, 0.003])
+    with pytest.raises(MalformedDataError, match="equal lengths"):
+        ReflectivityCurve(**columns)
 
 
 def test_empty_curve():


### PR DESCRIPTION
## Summary

Restructures the result dataclasses in `models/results.py` so each type expresses its output contract:

- **`ReflectivityCurve`** (new) — the reduced R(Q) data shared by both result types, as named arrays (`q, r, dr, dq` + optional `theta, lam, dtheta, dlam`). `to_array()` is the single place that knows the on-disk column order (Q, R, dR, dQ, then T, L, dT, dL), so producers never assemble positional columns themselves. Partially-supplied 8-column data is rejected at construction.
- **`ReductionResult`** — composes a curve and gains the identity fields the ORSO partial needs: `run_numbers` (plural when the run is a sum of source runs), `sequence_id`, `sequence_number`.
- **`CombinedReductionResult`** — no longer inherits from `ReductionResult`: a combined curve must not be accepted where a single-run partial is expected (e.g. as sequence-assembly input). It now carries the assembly *outputs* — `partials: list[ReductionResult]` (supplying the `data_files`/`additional_files` entries of the combined output, identical for the in-memory and on-disk front doors) and stitching `scale_factors` — replacing the `assembly_config` field, which duplicated `reduction_config.assembly`. `html_report` moves here, since the diagnostic report is per sequence.

The placeholder factories in `api/_shared.py` are updated to the new constructors; identity fields are zeroed there because the real values come from the run's NeXus logs, which the placeholders never see.

Notes for the ORSO reader/writer work in flight: the writer should consume exactly these fields, and `read_partials` should return `ReductionResult` objects (not raw arrays) so the two assembly front doors stay type-equivalent.

## Testing

- New `tests/unit/models/test_results.py`: 4- and 8-column `to_array()` ordering, rejection of partial 8-column input, empty-curve placeholder.
- All 45 new-workflow unit tests (`unit/models`, `unit/lr_reduction/api`, `unit/io`) pass; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)